### PR TITLE
feat: add visualization params form page

### DIFF
--- a/backend/calculatrice_monitoring/schemas.py
+++ b/backend/calculatrice_monitoring/schemas.py
@@ -5,6 +5,7 @@ from calculatrice_monitoring.models import Indicator
 
 class IndicatorSchema(ma.SQLAlchemyAutoSchema):
     id_indicator = ma.Integer(data_key="id")
+    id_protocol = ma.Integer(data_key="protocolId")
 
     class Meta:
         model = Indicator
@@ -14,3 +15,4 @@ class IndicatorSchema(ma.SQLAlchemyAutoSchema):
 class ProtocolSchema(ma.Schema):
     id_module = ma.Integer(data_key="id")
     module_label = ma.String(data_key="label")
+    module_code = ma.String(data_key="code")

--- a/backend/calculatrice_monitoring/tests/fixtures.py
+++ b/backend/calculatrice_monitoring/tests/fixtures.py
@@ -36,15 +36,20 @@ def protocol():
 def protocol_with_indicators(protocol):
     with db.session.begin_nested():
         indicator_names = ["Test Indicator", "Another Test Indicator", "Yet Another Test Indicator"]
+        indicators = []
         for name in indicator_names:
             indicator = Indicator(
                 name=name,
                 id_protocol=protocol.id_module,
                 description=f"This is the {name} indicator description.",
             )
+            indicators.append(indicator)
             db.session.add(indicator)
 
-    return protocol
+    return {
+        "protocol": protocol,
+        "indicators": indicators,
+    }
 
 
 @pytest.fixture()

--- a/backend/calculatrice_monitoring/tests/test_routes.py
+++ b/backend/calculatrice_monitoring/tests/test_routes.py
@@ -18,7 +18,7 @@ class TestGetIndicators:
     @pytest.mark.usefixtures("calculatrice_permissions")
     def test_get_indicators(self, client, users, protocol_with_indicators):
         set_logged_user(client, users["gestionnaire"])
-        id_protocol = protocol_with_indicators.id_module
+        id_protocol = protocol_with_indicators["protocol"].id_module
         response = client.get(url_for("calculatrice.get_indicators", id_protocol=id_protocol))
         assert response.status_code == 200
         expected_names = ["Another Test Indicator", "Test Indicator", "Yet Another Test Indicator"]
@@ -41,7 +41,7 @@ class TestGetIndicators:
     @pytest.mark.usefixtures("calculatrice_permissions")
     def test_error_endpoint_needs_read_permission(self, client, users, protocol_with_indicators):
         set_logged_user(client, users["public"])
-        id_protocol = protocol_with_indicators.id_module
+        id_protocol = protocol_with_indicators["protocol"].id_module
         response = client.get(url_for("calculatrice.get_indicators", id_protocol=id_protocol))
         assert response.status_code == 403
 

--- a/frontend/app/components/module/module.component.html
+++ b/frontend/app/components/module/module.component.html
@@ -36,7 +36,7 @@
             <a
               matListItemTitle
               class="list-item-container"
-              [routerLink]="['/calculatrice/visualize', indicator.id]"
+              [routerLink]="['/calculatrice/visualization', indicator.id, 'params']"
             >
               <span>{{ indicator.name }}</span>
               <button

--- a/frontend/app/components/visualization-page/visualization-page.component.ts
+++ b/frontend/app/components/visualization-page/visualization-page.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'pnx-calc-visualization-page',
+  template: `
+    <p>Sites: {{ sites | json }}</p>
+    <p>Campaigns: {{ campaigns | json }}</p>
+  `,
+})
+export class VisualizationPageComponent implements OnInit {
+  sites: string;
+  campaigns: string;
+
+  ngOnInit() {
+    this.sites = window.history.state.sites;
+    this.campaigns = window.history.state.campaigns;
+  }
+}

--- a/frontend/app/components/visualization-params-form/visualization-params-form.component.css
+++ b/frontend/app/components/visualization-params-form/visualization-params-form.component.css
@@ -1,0 +1,40 @@
+.container {
+  background: white;
+  padding: 1rem;
+}
+
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sites-group-form-container {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+}
+
+.sites-group-form-container ng-select {
+  width: 350px;
+}
+
+.campaigns-form-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.campaigns-form-container h4 {
+  display: inline-block;
+  margin: 0;
+}
+
+.campaigns-form-container button {
+  margin: 0;
+}
+
+.alert {
+  margin-top: 1rem;
+}

--- a/frontend/app/components/visualization-params-form/visualization-params-form.component.html
+++ b/frontend/app/components/visualization-params-form/visualization-params-form.component.html
@@ -1,0 +1,98 @@
+<div class="container mt-4">
+  <form
+    [formGroup]="campaignForm"
+    (ngSubmit)="onSubmit()"
+  >
+    <div class="form-container">
+      <div class="sites-group-form-container">
+        <h5>Groupe de sites</h5>
+        <ng-select
+          #sitesGroupSelect
+          id="sitesGroupSelect"
+          [items]="sitesGroupChoices"
+          bindLabel="name"
+          bindValue="id"
+          placeholder="Sélectionner un groupe de sites"
+          formControlName="sitesGroup"
+        ></ng-select>
+      </div>
+      <div formArrayName="campaigns">
+        <div class="campaigns-form-container">
+          <h4>Campagnes</h4>
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="addCampaign()"
+          >
+            + Ajouter une campagne
+          </button>
+        </div>
+        <div
+          *ngFor="let campaign of campaigns.controls; let i = index"
+          [formGroupName]="i"
+          class="campaign-item mb-3 p-3 border rounded"
+        >
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <h5>Campagne #{{ i + 1 }}</h5>
+            <button
+              *ngIf="campaigns.controls.length > 1"
+              type="button"
+              class="btn btn-danger btn-sm"
+              (click)="removeCampaign(i)"
+            >
+              Supprimer
+            </button>
+          </div>
+
+          <div class="row">
+            <div class="col-md-6">
+              <div class="form-group">
+                <label [for]="'startDate-' + i">Date de début</label>
+                <input
+                  [id]="'startDate-' + i"
+                  type="date"
+                  class="form-control"
+                  formControlName="startDate"
+                  (change)="onStartDateChange(campaign)"
+                />
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="form-group">
+                <label [for]="'endDate-' + i">Date de fin</label>
+                <input
+                  [id]="'endDate-' + i"
+                  type="date"
+                  class="form-control"
+                  formControlName="endDate"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            *ngIf="campaign.errors?.['endIsBeforeStart']"
+            class="alert alert-danger"
+          >
+            La fin de la campagne doit être après son début.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <hr />
+
+    <button
+      type="submit"
+      class="btn btn-success"
+      [disabled]="!campaignForm.valid"
+    >
+      Visualiser
+    </button>
+  </form>
+  <div
+    *ngIf="campaigns.errors?.['campaignsOverlap']"
+    class="alert alert-danger"
+  >
+    Les campagnes ne doivent pas se chevaucher.
+  </div>
+</div>

--- a/frontend/app/components/visualization-params-form/visualization-params-form.component.ts
+++ b/frontend/app/components/visualization-params-form/visualization-params-form.component.ts
@@ -1,0 +1,192 @@
+import { Component, OnInit } from '@angular/core';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import * as moment from 'moment';
+import { Indicator, Protocol, SitesGroup } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+
+interface Campaign {
+  startDate: string;
+  endDate: string;
+}
+
+interface SitesGroupChoice extends SitesGroup {
+  disabled?: boolean;
+}
+
+const noOverlappedCampaignsValidator: ValidatorFn = (
+  control: AbstractControl
+): ValidationErrors | null => {
+  const format = 'YYYY-MM-DD';
+  const campaigns: Campaign[] = control.value;
+  let overlapSpotted = false;
+  campaigns.forEach((camp1) => {
+    campaigns.forEach((camp2) => {
+      if (camp1 !== camp2) {
+        const start1 = moment(camp1.startDate, format);
+        const end1 = moment(camp1.endDate, format);
+        const start2 = moment(camp2.startDate, format);
+        const end2 = moment(camp2.endDate, format);
+        if (
+          !(
+            (start1.isBefore(start2) && end1.isBefore(start2)) ||
+            (start2.isBefore(start1) && end2.isBefore(start1))
+          )
+        ) {
+          overlapSpotted = true;
+        }
+      }
+    });
+  });
+  return overlapSpotted ? { campaignsOverlap: true } : null;
+};
+
+const endAfterStartValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const format = 'YYYY-MM-DD';
+  const start = moment(control.value.startDate, format);
+  const end = moment(control.value.endDate, format);
+  return end.isBefore(start) ? { endIsBeforeStart: true } : null;
+};
+
+@Component({
+  selector: 'pnx-calc-viz-params-form',
+  templateUrl: './visualization-params-form.component.html',
+  styleUrls: ['./visualization-params-form.component.css'],
+})
+export class VisualizationParamsFormComponent implements OnInit {
+  campaignForm: FormGroup;
+  sitesGroupChoices: Array<SitesGroupChoice> = undefined;
+  private sitesGroups: Array<SitesGroup> = undefined;
+  private protocolCode: string = undefined;
+
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _data: DataService,
+    private _router: Router,
+    private _route: ActivatedRoute
+  ) {
+    this.campaignForm = this._formBuilder.group({
+      sitesGroup: [null, Validators.required],
+      campaigns: this._formBuilder.array([], { validators: noOverlappedCampaignsValidator }),
+    });
+  }
+
+  ngOnInit(): void {
+    this._route.params.subscribe((params) => {
+      this._data.getIndicator(params.indicatorId).subscribe((indicator: Indicator) => {
+        this._data.getProtocol(indicator.protocolId).subscribe((protocol: Protocol) => {
+          this.protocolCode = protocol.code;
+          this._data.getSitesGroups(this.protocolCode).subscribe((data: Array<SitesGroup>) => {
+            this.sitesGroups = data;
+            this.sitesGroupChoices = this.getSitesGroupChoices(data);
+          });
+        });
+      });
+    });
+    this.addCampaign();
+  }
+
+  /**
+   * Getter pratique pour accéder facilement au FormArray depuis le template.
+   */
+  get campaigns(): FormArray {
+    return this.campaignForm.get('campaigns') as FormArray;
+  }
+
+  /**
+   * Crée un nouveau FormGroup pour une campagne.
+   */
+  newCampaign(): FormGroup {
+    return this._formBuilder.group(
+      {
+        startDate: ['', Validators.required],
+        endDate: ['', Validators.required],
+      },
+      { validators: endAfterStartValidator }
+    );
+  }
+
+  /**
+   * Ajoute une nouvelle campagne au FormArray.
+   */
+  addCampaign() {
+    let newCampaign = this.newCampaign();
+    this.campaigns.push(newCampaign);
+    const nbCampaigns = this.campaigns.value.length;
+    if (nbCampaigns > 1) {
+      const previousCampaign: Campaign = this.campaigns.value[nbCampaigns - 2];
+      const newCampaignStart = this.getNextDay(previousCampaign.endDate);
+      newCampaign.patchValue({
+        startDate: newCampaignStart,
+        endDate: this.getNextYear(newCampaignStart),
+      });
+    }
+  }
+
+  /**
+   * Supprime une campagne à un index spécifique.
+   */
+  removeCampaign(campaignIndex: number) {
+    this.campaigns.removeAt(campaignIndex);
+  }
+
+  onStartDateChange(campaignForm: FormControl) {
+    if (!campaignForm.value.endDate) {
+      campaignForm.patchValue({ endDate: this.getNextYear(campaignForm.value.startDate) });
+    }
+  }
+
+  /**
+   * Gère la soumission du formulaire.
+   */
+  onSubmit() {
+    if (this.campaignForm.valid) {
+      this._data
+        .getSites(
+          this.protocolCode,
+          this.sitesGroups.find((item) => item.id === this.campaignForm.value.sitesGroup)
+        )
+        .subscribe((sites) => {
+          this._router.navigate(['..'], {
+            relativeTo: this._route,
+            state: {
+              sites: sites,
+              campaigns: this.campaignForm.value.campaigns,
+            },
+          });
+        });
+    } else {
+      console.error('Le formulaire contient des erreurs.');
+    }
+  }
+
+  private getNextDay(date: string) {
+    const format = 'YYYY-MM-DD';
+    const dateObj = moment(date, format);
+    return dateObj.add(1, 'day').format(format);
+  }
+
+  private getNextYear(date: string) {
+    const format = 'YYYY-MM-DD';
+    const dateObj = moment(date, format);
+    return dateObj.add(1, 'year').subtract(1, 'day').format(format);
+  }
+
+  private getSitesGroupChoices(sitesGroups: SitesGroup[]) {
+    return sitesGroups.map<SitesGroupChoice>((group) => {
+      let groupChoice: SitesGroupChoice = structuredClone(group);
+      groupChoice.disabled = group.nbSites === 0;
+      if (groupChoice.disabled) groupChoice.name = `${groupChoice.name} (aucun site)`;
+      return groupChoice;
+    });
+  }
+}

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -1,23 +1,32 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { ModuleComponent } from './components/module/module.component';
-
+import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
+import { RouterModule, Routes } from '@angular/router';
+import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { ModuleComponent } from './components/module/module.component';
+import { VisualizationPageComponent } from './components/visualization-page/visualization-page.component';
+import { VisualizationParamsFormComponent } from './components/visualization-params-form/visualization-params-form.component';
 import { DataService } from './services/data.service';
 
-const routes: Routes = [{ path: '', component: ModuleComponent }];
+const routes: Routes = [
+  { path: '', component: ModuleComponent },
+  { path: 'visualization/:indicatorId/params', component: VisualizationParamsFormComponent },
+  { path: 'visualization/:indicatorId', component: VisualizationPageComponent },
+];
 
 @NgModule({
-  declarations: [ModuleComponent],
+  declarations: [ModuleComponent, VisualizationParamsFormComponent, VisualizationPageComponent],
   imports: [
     CommonModule,
     RouterModule.forChild(routes),
     MatListModule,
     MatIconModule,
     MatButtonModule,
+    ReactiveFormsModule,
+    GN2CommonModule,
   ],
   providers: [DataService],
   bootstrap: [ModuleComponent],

--- a/frontend/app/interfaces.ts
+++ b/frontend/app/interfaces.ts
@@ -1,10 +1,23 @@
-export type Indicator = {
+export interface Indicator {
   id: number;
   name: string;
   description: string;
-};
+  protocolId: number;
+}
 
 export interface Protocol {
   id: number;
   label: string;
+  code: string;
+}
+
+export interface SitesGroup {
+  id: number;
+  name: string;
+  nbSites: number;
+}
+
+export interface Site {
+  id: number;
+  name: string;
 }

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -1,9 +1,27 @@
-import { Injectable } from '@angular/core';
-
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { ConfigService } from '@geonature/services/config.service';
 import { ParamsDict } from '@geonature_common/form/data-form.service';
-import { Indicator, Protocol } from '../interfaces';
+import { from } from 'rxjs';
+import { Indicator, Protocol, Site, SitesGroup } from '../interfaces';
+
+interface MonitoringSitesGroup {
+  id_sites_group: number;
+  sites_group_name: string;
+  nb_sites: number;
+}
+
+interface MonitoringSite {
+  id_base_site: number;
+  base_site_name: string;
+}
+
+interface PaginatedList {
+  count: number;
+  items: Array<unknown>;
+  limit: number;
+  page: number;
+}
 
 @Injectable()
 export class DataService {
@@ -12,6 +30,17 @@ export class DataService {
     private _config: ConfigService
   ) {}
 
+  getProtocol(protocolId: number) {
+    return this._http.get<Protocol>(
+      `${this._config.API_ENDPOINT}/calculatrice/protocol/${protocolId}`
+    );
+  }
+
+  /**
+   * Returns the list of available monitoring protocols for the current user.
+   *
+   * params: parameters are passed as-is as query parameters to the request
+   */
   getProtocols(params: ParamsDict) {
     let httpParams = new HttpParams();
     for (const key in params) {
@@ -22,9 +51,95 @@ export class DataService {
     });
   }
 
+  getIndicator(indicatorId: number) {
+    return this._http.get<Indicator>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}`
+    );
+  }
+
+  /**
+   * Returns the list of indicators associated with the given protocol.
+   */
   getIndicators(protocolId: number) {
     return this._http.get<Array<Indicator>>(
       `${this._config.API_ENDPOINT}/calculatrice/indicators?id_protocol=${protocolId}`
     );
+  }
+
+  /**
+   * Returns the list of sites groups for the given protocol.
+   */
+  getSitesGroups(protocolCode: string) {
+    const url = `${this._config.API_ENDPOINT}/monitorings/refacto/${protocolCode}/sites_groups`;
+    const params = {
+      sort_dir: 'asc',
+      sort: 'sites_group_name',
+    };
+    function transform(items: Array<MonitoringSitesGroup>): Array<SitesGroup> {
+      return items.map<SitesGroup>((item) => ({
+        id: item.id_sites_group,
+        name: item.sites_group_name,
+        nbSites: item.nb_sites,
+      }));
+    }
+    return from(
+      this.getAll<MonitoringSitesGroup>(url, params, 'id_sites_group').then((items) =>
+        transform(items)
+      )
+    );
+  }
+
+  /**
+   * Returns the list of sites for the given protocol and sites group.
+   */
+  getSites(protocolCode: string, sitesGroup: SitesGroup) {
+    const url = `${this._config.API_ENDPOINT}/monitorings/refacto/${protocolCode}/sites`;
+    const params = {
+      sort_dir: 'asc',
+      sort: 'base_site_name',
+      id_sites_group: sitesGroup.id,
+    };
+    function transform(items: Array<MonitoringSite>): Array<Site> {
+      return items.map<Site>((item) => ({
+        id: item.id_base_site,
+        name: item.base_site_name,
+      }));
+    }
+    return from(
+      this.getAll<MonitoringSite>(url, params, 'id_base_site').then((items) => transform(items))
+    );
+  }
+
+  private async getPage(url: string, params: ParamsDict): Promise<PaginatedList> {
+    let httpParams = new HttpParams();
+    for (const key in params) {
+      httpParams = httpParams.set(key, params[key].toString());
+    }
+    return this._http.get(url, { params: httpParams }).toPromise() as Promise<PaginatedList>;
+  }
+
+  /**
+   * Utility method to fetch all pages of a paginated endpoint and return a concatenated list.
+   */
+  private async getAll<T>(url: string, params: ParamsDict, uniqueKey: string): Promise<Array<T>> {
+    const pageSize = 100;
+    let page = 1;
+    params.page = page;
+    params.limit = pageSize;
+    const result = await this.getPage(url, params);
+    let items = result.items;
+    const nbPages = Math.ceil(result.count / pageSize);
+    page += 1;
+    while (page <= nbPages) {
+      params.page = page;
+      const nextResult = await this.getPage(url, params);
+      nextResult.items.forEach((nextItem) => {
+        // We check for unicity in the event where the list changes as we are iterating on the pages
+        if (items.findIndex((item) => item[uniqueKey] === nextItem[uniqueKey]) === -1)
+          items.push(nextItem);
+      });
+      page += 1;
+    }
+    return items as Array<T>;
   }
 }


### PR DESCRIPTION
Issue #13 

Description de la PR :

- nouvelle page à `/calculatrice/visualization/<indicator_id>/params`
- permet de sélectionner un groupe de sites parmi ceux visibles pour l'utilisateur
  + les groupes de sites ne possédant pas de sites sont visibles dans la liste mais désactivés (en vérifiant la propriété `nb_sites` retournée par l'API de gn-monitoring)
- permet de sélectionner une ou plusieurs campagnes
  + validation que la date de fin est après la date de début pour chacune
  + validation que les campagnes ne se chevauchent pas
  + saisie rapide : choisir une date de début auto-saisit la date de fin si absente à (1 an - 1 jour)
  + saisie rapide : si la date de fin de la dernière campagne a été saisie l'ajout d'une nouvelle campagne auto-saisit les dates
- les valeurs du formulaire sont passées à la page suivante avec le `history.state`
  + une dummy page est ajoutée pour vérifier que les valeurs arrivent bien sur la prochaine page : `/calculatrice/visualization/<indicator_id>`