### PR TITLE
feat: add visualization page

### DIFF
--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, abort, request
 from flask_login import login_required
-from flask_parameter_validation import Query, ValidateParameters
+from flask_parameter_validation import Json, Query, Route, ValidateParameters
 from geonature.core.gn_permissions.decorators import check_cruved_scope
 from geonature.core.gn_permissions.tools import get_scopes_by_action
 from geonature.utils.env import db
@@ -78,3 +78,94 @@ def get_protocols(with_indicators_only: bool = Query(False)):
         if scopes["R"] > 0:
             modules.append(module)
     return ProtocolSchema().jsonify(modules, many=True)
+
+
+# The method is POST in order to pass parameters with the body. Since two parameters are
+# lists of unknown size (sites IDs and campaigns) we want to avoid reaching the URL max length
+# limit at some point.
+@blueprint.route("/indicator/<int:indicator_id>/visualize", methods=["POST"])
+@check_cruved_scope(action="R", module_code=MODULE_CODE, object_code="CALCULATRICE_INDICATOR")
+@ValidateParameters()
+def get_indicator_visualization(
+    indicator_id: int = Route(),
+    sites_ids: list[int] = Json(),  # noqa: B008  # Calling Json function for a default parameter is
+    campaigns: list[str] = Json(),  # noqa: B008  # the way flask-parameter-validation works.
+    viz_type: str = Json(),  # noqa: B008
+):
+    if len(campaigns) > 1:
+        return [
+            {
+                "title": "Un bloc représentant un résultat scalaire",
+                "info": "foobar",
+                "description": f"""
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac tempor felis. Cras ut
+blandit ipsum, rutrum blandit justo. Sed accumsan est ut consequat rhoncus. Nunc luctus rutrum
+eros a suscipit.</p>
+<ul>
+    <li>indicator ID : {indicator_id}</li>
+    <li>sites IDs : {sites_ids}</li>
+    <li>campaigns : {campaigns}</li>
+    <li>type : {viz_type}</li>
+</ul>
+<img src="https://geonature.fr/img/geonature-logo.jpg"/>
+<p>Nulla facilisi. Donec vel erat placerat, iaculis mauris in, commodo metus.</p>""",
+                "type": "scalaire",
+                "data": {
+                    "figure": 6.2,
+                },
+            },
+            {
+                "title": "Valeur HE pour chaque quadrat",
+                "type": "barChart",
+                "info": """
+<p>In eu ultrices ex. Maecenas ultricies, metus eget porta tincidunt, velit odio efficitur magna,
+nec aliquet erat orci sed elit. Vivamus elementum ante eget maximus pellentesque. Aenean sit amet
+erat nec tortor vestibulum auctor. Mauris dapibus elit at ligula laoreet sollicitudin. Morbi
+at condimentum enim.</p>
+<img src="https://geonature.fr/img/geonature-logo.jpg"/>
+<p>Nulla facilisi. Donec vel erat placerat, iaculis mauris in, commodo metus.</p>""",
+                "description": f"""
+<p>Maecenas ultricies, metus eget porta tincidunt, velit odio efficitur magna,
+nec aliquet erat orci sed elit. Vivamus elementum ante eget maximus pellentesque. Aenean
+sit amet erat nec tortor vestibulum auctor. Mauris dapibus elit at ligula laoreet sollicitudin.
+Morbi at condimentum enim.</p>
+<ul>
+    <li>indicator ID : {indicator_id}</li>
+    <li>sites IDs : {sites_ids}</li>
+    <li>campaigns : {campaigns}</li>
+    <li>type : {viz_type}</li>
+</ul>
+<img src="https://geonature.fr/img/geonature-logo.jpg"/>
+<p>Nulla facilisi. Donec vel erat placerat, iaculis mauris in, commodo metus.</p>""",
+                "data": {
+                    "labels": ["Q1", "Q2", "Q3"],
+                    "datasets": [{"data": [5.5, 6.7, 4.9], "label": "Series A"}],
+                },
+            },
+        ]
+    else:
+        return [
+            {
+                "title": "Un bloc représentant un résultat scalaire",
+                "info": "foobar",
+                "description": f"""
+<p>Aliquam varius vestibulum
+ante ut tincidunt. In eu ultrices ex. Maecenas ultricies, metus eget porta tincidunt, velit
+odio efficitur magna, nec aliquet erat orci sed elit. Vivamus elementum ante eget maximus
+pellentesque. Aenean sit amet erat nec tortor vestibulum auctor. Mauris dapibus elit at ligula
+laoreet sollicitudin. Morbi at condimentum enim.</p>
+<ul>
+    <li>indicator ID : {indicator_id}</li>
+    <li>sites IDs : {sites_ids}</li>
+    <li>campaigns : {campaigns}</li>
+    <li>type : {viz_type}</li>
+</ul>
+<img src="https://geonature.fr/img/geonature-logo.jpg"/>
+<p>Nulla facilisi. Donec vel erat placerat, iaculis mauris in, commodo metus.Mauris dapibus elit
+at ligula laoree sollicitudin. Morbi at condimentum enim.</p>""",
+                "type": "scalaire",
+                "data": {
+                    "figure": 7.9,
+                },
+            },
+        ]

--- a/frontend/app/components/visualization-block/visualization-block.component.css
+++ b/frontend/app/components/visualization-block/visualization-block.component.css
@@ -1,0 +1,27 @@
+mat-card {
+  max-width: 1170px;
+  margin: auto;
+}
+
+mat-card strong {
+  font-size: 3rem;
+}
+
+mat-card-title h1 {
+  padding: 0.3rem 1rem;
+}
+
+/* ::ng-deep is required to style elements inserted with [innerHTML] binding */
+::ng-deep .description img {
+  display: block;
+  margin: auto;
+}
+
+.graphics-row {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+  margin: 1.8rem;
+  align-items: center;
+}

--- a/frontend/app/components/visualization-block/visualization-block.component.html
+++ b/frontend/app/components/visualization-block/visualization-block.component.html
@@ -1,0 +1,45 @@
+<mat-card>
+  <mat-card-title>
+    <h1>{{ blockDef.title }}</h1>
+  </mat-card-title>
+  <mat-card-content>
+    <div class="graphics-row">
+      <div #viewContainer></div>
+      <button
+        mat-icon-button
+        (click)="onInformationClick($event)"
+      >
+        <mat-icon>info</mat-icon>
+      </button>
+    </div>
+    <div
+      class="description"
+      [innerHTML]="blockDef.description"
+    ></div>
+  </mat-card-content>
+</mat-card>
+<ng-template
+  #infoModal
+  let-modal
+>
+  <div class="modal-header">
+    <h4
+      class="modal-title"
+      id="modal-basic-title"
+    >
+      {{ blockDef.title }}
+    </h4>
+    <button
+      type="button"
+      class="close"
+      aria-label="Close"
+      (click)="modal.dismiss('Cross click')"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div
+    class="modal-body"
+    [innerHTML]="blockDef.info"
+  ></div>
+</ng-template>

--- a/frontend/app/components/visualization-block/visualization-block.component.ts
+++ b/frontend/app/components/visualization-block/visualization-block.component.ts
@@ -1,0 +1,45 @@
+import {
+  AfterViewInit,
+  Component,
+  ComponentRef,
+  Input,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { VisualizationBlockDefinition } from '../../interfaces';
+import { VisualizationChartComponent } from '../visualization-chart/visualization-chart.component';
+import { VisualizationScalarComponent } from '../visualization-scalar/visualization-scalar.component';
+
+@Component({
+  selector: 'pnx-calc-visualization-block',
+  templateUrl: './visualization-block.component.html',
+  styleUrls: ['./visualization-block.component.css'],
+})
+export class VisualizationBlockComponent implements AfterViewInit {
+  @Input() blockDef: VisualizationBlockDefinition;
+  @ViewChild('infoModal') protected modalContent: TemplateRef<any>;
+  @ViewChild('viewContainer', { read: ViewContainerRef }) private _vcr: ViewContainerRef;
+
+  constructor(private _modalService: NgbModal) {}
+
+  ngAfterViewInit() {
+    // An initialized view is needed to use the ViewContainerRef but the goal is to change the view
+    // itself by adding a dynamic component. The view is already rendered so one must act
+    // at the next tick with a timeout.
+    setTimeout(() => {
+      let ref: ComponentRef<any> = undefined;
+      if (this.blockDef.type === 'scalaire') {
+        ref = this._vcr.createComponent(VisualizationScalarComponent);
+      } else if (this.blockDef.type === 'barChart') {
+        ref = this._vcr.createComponent(VisualizationChartComponent);
+      }
+      ref!.setInput('data', this.blockDef.data);
+    });
+  }
+
+  onInformationClick(event: MouseEvent) {
+    this._modalService.open(this.modalContent, { size: 'xl' });
+  }
+}

--- a/frontend/app/components/visualization-chart/visualization-chart.component.css
+++ b/frontend/app/components/visualization-chart/visualization-chart.component.css
@@ -1,0 +1,3 @@
+.canvas-container {
+  width: 600px;
+}

--- a/frontend/app/components/visualization-chart/visualization-chart.component.html
+++ b/frontend/app/components/visualization-chart/visualization-chart.component.html
@@ -1,0 +1,7 @@
+<div class="canvas-container">
+  <canvas
+    baseChart
+    [data]="data"
+    [type]="barChartType"
+  ></canvas>
+</div>

--- a/frontend/app/components/visualization-chart/visualization-chart.component.ts
+++ b/frontend/app/components/visualization-chart/visualization-chart.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { BarChartVisualizationBlockData } from '../../interfaces';
+
+@Component({
+  selector: 'pnx-calc-visualization-chart',
+  templateUrl: './visualization-chart.component.html',
+  styleUrls: ['./visualization-chart.component.css'],
+})
+export class VisualizationChartComponent {
+  barChartType = 'bar' as const;
+  @Input() data: BarChartVisualizationBlockData;
+}

--- a/frontend/app/components/visualization-page/visualization-page.component.css
+++ b/frontend/app/components/visualization-page/visualization-page.component.css
@@ -1,0 +1,31 @@
+.blocks-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.visualization-page {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 1rem;
+}
+
+.visualization-toc li {
+  list-style: none;
+  border-left: solid 2px black;
+  padding-left: 0.4rem;
+}
+
+.visualization-toc a {
+  text-decoration: none;
+  color: black;
+}
+
+.visualization-toc a:hover {
+  text-decoration: underline;
+}
+
+.visualization-toc a.active {
+  color: #673ab7;
+  border-left-color: #673ab7;
+}

--- a/frontend/app/components/visualization-page/visualization-page.component.html
+++ b/frontend/app/components/visualization-page/visualization-page.component.html
@@ -1,0 +1,33 @@
+<div class="visualization-page">
+  <div class="visualization-nav">
+    <mat-selection-list
+      role="list"
+      hideSingleSelectionIndicator
+      #selectionsList
+      [multiple]="false"
+      (selectionChange)="onSelectionsChange(selectionsList.selectedOptions.selected)"
+    >
+      <mat-list-option
+        *ngFor="let selection of selections; index as i"
+        [value]="selection"
+        [selected]="selection && i === 0"
+        class="mat-elevation-z2"
+      >
+        {{ selection.label }}
+      </mat-list-option>
+    </mat-selection-list>
+  </div>
+  <div class="blocks-container">
+    <pnx-calc-visualization-block
+      *ngFor="let block of vizBlocks"
+      [blockDef]="block"
+    ></pnx-calc-visualization-block>
+  </div>
+  <div class="visualization-toc">
+    <ul>
+      <li *ngFor="let block of vizBlocks">
+        <a href="#{{ block.title }}">{{ block.title }}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/frontend/app/components/visualization-page/visualization-page.component.ts
+++ b/frontend/app/components/visualization-page/visualization-page.component.ts
@@ -1,18 +1,94 @@
 import { Component, OnInit } from '@angular/core';
+import { MatListOption } from '@angular/material/list';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Campaign, Site, VisualizationBlockDefinition } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+
+interface Selection {
+  label: string;
+  type: 'synthese' | 'campaign' | 'evolution';
+  campaigns: Campaign[];
+}
 
 @Component({
   selector: 'pnx-calc-visualization-page',
-  template: `
-    <p>Sites: {{ sites | json }}</p>
-    <p>Campaigns: {{ campaigns | json }}</p>
-  `,
+  templateUrl: './visualization-page.component.html',
+  styleUrls: ['./visualization-page.component.css'],
 })
 export class VisualizationPageComponent implements OnInit {
-  sites: string;
-  campaigns: string;
+  protected vizBlocks: VisualizationBlockDefinition[];
+  protected selections: Selection[];
+  private _sites: Site[];
+  private _campaigns: Campaign[];
+  private _indicatorId: number;
+
+  constructor(
+    private _data: DataService,
+    private _router: Router,
+    private _route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
-    this.sites = window.history.state.sites;
-    this.campaigns = window.history.state.campaigns;
+    this._sites = window.history.state.sites;
+    this._campaigns = window.history.state.campaigns;
+    if (this._sites === undefined || this._campaigns === undefined) {
+      this._router.navigate(['./params'], {
+        relativeTo: this._route,
+      });
+    }
+    this.selections = this._buildSelections(this._campaigns);
+    this._route.params.subscribe((params) => {
+      this._indicatorId = params.indicatorId;
+      const firstSelection = this.selections[0];
+      // The first selection is also visually selected in the template.
+      this._updateVisualization(firstSelection);
+    });
+  }
+
+  onSelectionsChange(items: MatListOption[]) {
+    // The selection list is configured to allow single item selection only.
+    let selection: Selection = items[0].value;
+    this._updateVisualization(selection);
+  }
+
+  private _buildSelections(campaigns: Campaign[]): Selection[] {
+    let selections: Selection[] = [];
+    if (campaigns.length > 1) {
+      selections.push({
+        label: 'Synthèse',
+        type: 'synthese',
+        campaigns: campaigns,
+      });
+    }
+    let previousCampaign = undefined;
+    campaigns.forEach((campaign) => {
+      if (previousCampaign !== undefined) {
+        selections.push({
+          label: `Évolution`,
+          type: 'evolution',
+          campaigns: [previousCampaign, campaign],
+        });
+      }
+      selections.push({
+        label: `Campagne ${campaign.startDate}-${campaign.endDate}`,
+        type: 'campaign',
+        campaigns: [campaign],
+      });
+      previousCampaign = campaign;
+    });
+    return selections;
+  }
+
+  private _updateVisualization(vizSelection: Selection) {
+    this._data
+      .getVisualizationBlocks(
+        this._indicatorId,
+        this._sites,
+        vizSelection.campaigns,
+        vizSelection.type
+      )
+      .subscribe((data) => {
+        this.vizBlocks = data;
+      });
   }
 }

--- a/frontend/app/components/visualization-scalar/visualization-scalar.component.css
+++ b/frontend/app/components/visualization-scalar/visualization-scalar.component.css
@@ -1,0 +1,5 @@
+strong {
+  border: solid 5px black;
+  border-radius: 10px;
+  padding: 0.5rem 1rem;
+}

--- a/frontend/app/components/visualization-scalar/visualization-scalar.component.html
+++ b/frontend/app/components/visualization-scalar/visualization-scalar.component.html
@@ -1,0 +1,1 @@
+<strong>{{ data.figure }}</strong>

--- a/frontend/app/components/visualization-scalar/visualization-scalar.component.ts
+++ b/frontend/app/components/visualization-scalar/visualization-scalar.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { ScalarVisualizationBlockData } from '../../interfaces';
+
+@Component({
+  selector: 'pnx-calc-visualization-scalar',
+  templateUrl: './visualization-scalar.component.html',
+  styleUrls: ['./visualization-scalar.component.css'],
+})
+export class VisualizationScalarComponent {
+  @Input() data: ScalarVisualizationBlockData;
+}

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -2,13 +2,18 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { RouterModule, Routes } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { NgChartsModule } from 'ng2-charts';
 import { ModuleComponent } from './components/module/module.component';
+import { VisualizationBlockComponent } from './components/visualization-block/visualization-block.component';
+import { VisualizationChartComponent } from './components/visualization-chart/visualization-chart.component';
 import { VisualizationPageComponent } from './components/visualization-page/visualization-page.component';
 import { VisualizationParamsFormComponent } from './components/visualization-params-form/visualization-params-form.component';
+import { VisualizationScalarComponent } from './components/visualization-scalar/visualization-scalar.component';
 import { DataService } from './services/data.service';
 
 const routes: Routes = [
@@ -18,15 +23,24 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  declarations: [ModuleComponent, VisualizationParamsFormComponent, VisualizationPageComponent],
+  declarations: [
+    ModuleComponent,
+    VisualizationParamsFormComponent,
+    VisualizationPageComponent,
+    VisualizationBlockComponent,
+    VisualizationChartComponent,
+    VisualizationScalarComponent,
+  ],
   imports: [
     CommonModule,
     RouterModule.forChild(routes),
     MatListModule,
     MatIconModule,
     MatButtonModule,
+    MatCardModule,
     ReactiveFormsModule,
     GN2CommonModule,
+    NgChartsModule,
   ],
   providers: [DataService],
   bootstrap: [ModuleComponent],

--- a/frontend/app/interfaces.ts
+++ b/frontend/app/interfaces.ts
@@ -21,3 +21,27 @@ export interface Site {
   id: number;
   name: string;
 }
+
+export type ScalarVisualizationBlockData = {
+  figure: number;
+};
+
+export type BarChartVisualizationBlockData = {
+  labels: string[];
+  datasets: any[];
+};
+
+export type VisualizationBlockData = ScalarVisualizationBlockData | BarChartVisualizationBlockData;
+
+export interface VisualizationBlockDefinition {
+  title: string;
+  info: string;
+  description: string;
+  type: 'scalaire' | 'barChart';
+  data: VisualizationBlockData;
+}
+
+export interface Campaign {
+  startDate: string;
+  endDate: string;
+}

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -3,7 +3,14 @@ import { Injectable } from '@angular/core';
 import { ConfigService } from '@geonature/services/config.service';
 import { ParamsDict } from '@geonature_common/form/data-form.service';
 import { from } from 'rxjs';
-import { Indicator, Protocol, Site, SitesGroup } from '../interfaces';
+import {
+  Campaign,
+  Indicator,
+  Protocol,
+  Site,
+  SitesGroup,
+  VisualizationBlockDefinition,
+} from '../interfaces';
 
 interface MonitoringSitesGroup {
   id_sites_group: number;
@@ -107,6 +114,26 @@ export class DataService {
     }
     return from(
       this.getAll<MonitoringSite>(url, params, 'id_base_site').then((items) => transform(items))
+    );
+  }
+
+  getVisualizationBlocks(
+    indicatorId: number,
+    sites: Site[],
+    campaigns: Campaign[],
+    visualizationType: string
+  ) {
+    return this._http.post<VisualizationBlockDefinition[]>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}/visualize`,
+      {
+        indicator_id: indicatorId,
+        sites_ids: sites.map<number>((item) => item.id),
+        campaigns: campaigns.map((item) => ({
+          start_date: item.startDate,
+          end_date: item.endDate,
+        })),
+        viz_type: visualizationType,
+      }
     );
   }
 


### PR DESCRIPTION
Issue #14 

Capture et explications de la page visualisation :

<img width="1425" height="773" alt="présentation page visualisation excalidraw" src="https://github.com/user-attachments/assets/3cd85db0-6138-4b24-98b7-b6dee9fa201d" />

Concepts (en gras les nouveaux concepts) :

- indicateur : ensemble des éléments permettant de calculer des valeurs indicatrices et de les restituer (codes python, configuration de la visualisation).
- visualisation : ensemble des sélections de visualisation d'un indicateur restituées à partir de la configuration.
- **sélection** : une visualisation d'indicateur comporte plusieurs parties, les sélections.
- types de sélection : synthèse, campagne, **évolution**.
- **bloc de visualisation** : une sélection de visualisation se compose d'une suite d'éléments appelés « bloc ». La définition et l'ordre de ses blocs est configurable sur la page d'administration d'un indicateur. _Le concept de bloc est une proposition de renommage pour la représentation graphique_.

Remarque :

Les données de la visualisation sont en dur dans le code du endpoint `get_indicator_visualization`. Pour étendre les possibilités de test de l'application les données retournées sont différentes selon le nombre de campagnes dans la sélection demandée.