### PR TITLE
Feat/add indicator creation

### DIFF
--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -5,15 +5,66 @@ from geonature.core.gn_permissions.decorators import check_cruved_scope
 from geonature.core.gn_permissions.tools import get_scopes_by_action
 from geonature.utils.env import db
 from gn_module_monitoring.monitoring.models import TMonitoringModules, TMonitoringSites
+from marshmallow import ValidationError
 from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
 from werkzeug.datastructures import MultiDict
 
 from calculatrice_monitoring import MODULE_CODE
 from calculatrice_monitoring.eval import visualize
-from calculatrice_monitoring.models import Indicator
-from calculatrice_monitoring.schemas import IndicatorDetailsSchema, IndicatorSchema, ProtocolSchema
+from calculatrice_monitoring.models import Indicator, ReferenceTable, VizBlockConfig
+from calculatrice_monitoring.schemas import (
+    IndicatorCreationSchema,
+    IndicatorDetailsSchema,
+    IndicatorSchema,
+    ProtocolSchema,
+    ReferenceTableSchema,
+    VizBlockConfigSchema,
+)
+from calculatrice_monitoring.utils import extract_variable_names
 
 blueprint = Blueprint("calculatrice", __name__)
+
+
+def _fetch_reference_tables(reference_table_ids):
+    """Returns the ReferenceTable rows matching the given ids.
+
+    Raises a ValueError with the set of unknown ids if some are not found.
+    """
+    reference_tables = db.session.scalars(
+        select(ReferenceTable).filter(ReferenceTable.id_reference_table.in_(reference_table_ids))
+    ).all()
+    missing_ids = set(reference_table_ids) - {rt.id_reference_table for rt in reference_tables}
+    if missing_ids:
+        raise ValueError(missing_ids)
+    return reference_tables
+
+
+def _validate_indicator_relations(data):
+    """Validates the protocol and reference tables referenced by an indicator payload.
+
+    `data` is mutated: `reference_table_ids` is popped out of it.
+    Returns a tuple `(reference_tables, error_response)`: on failure, `reference_tables`
+    is None and `error_response` is the `(body, status)` tuple to return to the client.
+    """
+    protocol_id = data["id_protocol"]
+    try:
+        db.session.scalars(
+            select(TMonitoringModules).filter(TMonitoringModules.id_module == protocol_id)
+        ).one()
+    except NoResultFound:
+        return None, ({"protocolId": [f"Protocol with ID {protocol_id} not found"]}, 400)
+
+    reference_table_ids = data.pop("reference_table_ids", [])
+    try:
+        reference_tables = _fetch_reference_tables(reference_table_ids)
+    except ValueError as error:
+        missing_ids = sorted(error.args[0])
+        return None, (
+            {"referenceTableIds": [f"Reference table(s) with ID {missing_ids} not found"]},
+            400,
+        )
+    return reference_tables, None
 
 
 @blueprint.route("/protocol/<int:protocol_id>", methods=["GET"])
@@ -30,6 +81,85 @@ def get_protocol(protocol_id: int):
     return ProtocolSchema().jsonify(protocol)
 
 
+@blueprint.route("/indicator", methods=["POST"])
+@check_cruved_scope(action="C", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def create_indicator():
+    try:
+        data = IndicatorCreationSchema().load(request.json)
+    except ValidationError as error:
+        return error.messages, 400
+    reference_tables, error_response = _validate_indicator_relations(data)
+    if error_response:
+        return error_response
+    indicator = Indicator(**data)
+    indicator.reference_tables = reference_tables
+    db.session.add(indicator)
+    db.session.commit()
+    return IndicatorSchema().jsonify(indicator), 201
+
+
+@blueprint.route("/indicator/<int:indicator_id>", methods=["PUT"])
+@check_cruved_scope(action="U", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def edit_indicator(indicator_id: int):
+    error_msg = f"Indicator {indicator_id} not found"
+    indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
+
+    # TODO: rename schema to IndicAttributsSchema
+    schema = IndicatorCreationSchema()
+    try:
+        data = schema.load(request.json)
+    except ValidationError as error:
+        # TODO: check needed
+        return error.messages, 400
+    reference_tables, error_response = _validate_indicator_relations(data)
+    if error_response:
+        return error_response
+
+    for field in schema.load_fields.keys():
+        if field == "reference_table_ids":
+            continue
+        if field in data:
+            setattr(indicator, field, data[field])
+        else:
+            column_default = getattr(Indicator, field).expression.default
+            setattr(indicator, field, column_default.arg if column_default else None)
+    indicator.reference_tables = reference_tables
+
+    db.session.add(indicator)
+    db.session.commit()
+    return IndicatorSchema().jsonify(indicator), 200
+
+
+@blueprint.route("/indicator/<int:indicator_id>/code", methods=["PUT"])
+@check_cruved_scope(action="U", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def edit_indicator_code(indicator_id: int):
+    error_msg = f"Indicator {indicator_id} not found"
+    indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
+    indicator.code = request.json["code"]
+    db.session.add(indicator)
+    db.session.commit()
+    return "", 204
+
+
+@blueprint.route("/indicator/<int:indicator_id>/viz-blocks", methods=["PUT"])
+@check_cruved_scope(action="U", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def update_indicator_viz_blocks(indicator_id: int):
+    error_msg = f"Indicator {indicator_id} not found"
+    indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
+    data = VizBlockConfigSchema(many=True).load(request.json)
+    # Delete previous vizblock configs
+    for old_vb in indicator.viz_block_configs:
+        db.session.delete(old_vb)
+    indicator.viz_block_configs.clear()
+    # Create and attach new ones
+    for vb_config in data:
+        vb = VizBlockConfig(**vb_config)
+        indicator.viz_block_configs.append(vb)
+    db.session.add(indicator)
+    db.session.commit()
+    return "", 204
+
+
 @blueprint.route("/indicator/<int:indicator_id>", methods=["GET"])
 @check_cruved_scope(action="R", module_code=MODULE_CODE)
 def get_indicator(indicator_id: int):
@@ -44,6 +174,15 @@ def get_indicator_details(indicator_id: int):
     error_msg = f"Indicator {indicator_id} not found"
     indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
     return IndicatorDetailsSchema().jsonify(indicator)
+
+
+@blueprint.route("/indicator/<int:indicator_id>/code-variables", methods=["GET"])
+@check_cruved_scope(action="R", module_code=MODULE_CODE)
+def get_indicator_code_variables(indicator_id: int):
+    error_msg = f"Indicator {indicator_id} not found"
+    indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
+    variables = extract_variable_names(indicator.code)
+    return variables, 200
 
 
 @blueprint.route("/indicators", methods=["GET"])
@@ -152,3 +291,10 @@ eros a suscipit.</p>
                 },
             },
         ]
+
+
+@blueprint.route("/reftables", methods=["GET"])
+@check_cruved_scope(action="R", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def get_reference_tables():
+    reftables = db.session.execute(db.select(ReferenceTable)).scalars()
+    return ReferenceTableSchema().jsonify(reftables, many=True)

--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -55,7 +55,7 @@ def _validate_indicator_relations(data):
     except NoResultFound:
         return None, ({"protocolId": [f"Protocol with ID {protocol_id} not found"]}, 400)
 
-    reference_table_ids = data.pop("reference_table_ids", [])
+    reference_table_ids = data.get("reference_table_ids", [])
     try:
         reference_tables = _fetch_reference_tables(reference_table_ids)
     except ValueError as error:

--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -108,7 +108,6 @@ def edit_indicator(indicator_id: int):
     try:
         data = schema.load(request.json)
     except ValidationError as error:
-        # TODO: check needed
         return error.messages, 400
     reference_tables, error_response = _validate_indicator_relations(data)
     if error_response:

--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -14,7 +14,7 @@ from calculatrice_monitoring import MODULE_CODE
 from calculatrice_monitoring.eval import visualize
 from calculatrice_monitoring.models import Indicator, ReferenceTable, VizBlockConfig
 from calculatrice_monitoring.schemas import (
-    IndicatorCreationSchema,
+    IndicatorAttributesSchema,
     IndicatorDetailsSchema,
     IndicatorSchema,
     ProtocolSchema,
@@ -85,7 +85,7 @@ def get_protocol(protocol_id: int):
 @check_cruved_scope(action="C", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
 def create_indicator():
     try:
-        data = IndicatorCreationSchema().load(request.json)
+        data = IndicatorAttributesSchema().load(request.json)
     except ValidationError as error:
         return error.messages, 400
     reference_tables, error_response = _validate_indicator_relations(data)
@@ -104,8 +104,7 @@ def edit_indicator(indicator_id: int):
     error_msg = f"Indicator {indicator_id} not found"
     indicator = db.get_or_404(Indicator, indicator_id, description=error_msg)
 
-    # TODO: rename schema to IndicAttributsSchema
-    schema = IndicatorCreationSchema()
+    schema = IndicatorAttributesSchema()
     try:
         data = schema.load(request.json)
     except ValidationError as error:

--- a/backend/calculatrice_monitoring/migrations/3415c1736b4d_add_description_to_indicators.py
+++ b/backend/calculatrice_monitoring/migrations/3415c1736b4d_add_description_to_indicators.py
@@ -22,6 +22,7 @@ def upgrade():
         sa.Column(
             "description",
             sa.Unicode(),
+            default="",
         ),
         schema="gn_calculatrice",
     )

--- a/backend/calculatrice_monitoring/models.py
+++ b/backend/calculatrice_monitoring/models.py
@@ -45,7 +45,7 @@ class Indicator(db.Model):
     id_indicator = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Unicode(100), nullable=False)
     id_protocol = db.Column(db.ForeignKey("gn_monitoring.t_module_complements.id_module"))
-    description = db.Column(db.Unicode)
+    description = db.Column(db.Unicode, default="")
     code = db.Column(db.Unicode, nullable=False, default="")
     protocol = db.relationship(TMonitoringModules)
     reference_tables = db.relationship(

--- a/backend/calculatrice_monitoring/models.py
+++ b/backend/calculatrice_monitoring/models.py
@@ -64,11 +64,13 @@ class VizBlockConfig(db.Model):
     __table_args__ = {"schema": "gn_calculatrice"}
 
     id_viz_block_config = db.Column(db.Integer, primary_key=True)
-    id_indicator = db.Column(db.ForeignKey("gn_calculatrice.t_indicators.id_indicator"))
+    id_indicator = db.Column(
+        db.ForeignKey("gn_calculatrice.t_indicators.id_indicator"), nullable=False
+    )
     title = db.Column(db.Unicode(100), nullable=False)
     info = db.Column(db.Unicode, nullable=False, default="")
     description = db.Column(db.Unicode, nullable=False, default="")
-    type = db.Column(Enum(VizBlockType, inherit_schema=True))
+    type = db.Column(Enum(VizBlockType, inherit_schema=True), nullable=False)
     params = db.Column(JSONB)
     indicator = db.relationship(Indicator)
 

--- a/backend/calculatrice_monitoring/schemas.py
+++ b/backend/calculatrice_monitoring/schemas.py
@@ -10,7 +10,10 @@ from calculatrice_monitoring.models import (
 
 class VizBlockConfigSchema(ma.SQLAlchemyAutoSchema):
     id_viz_block_config = ma.Integer(data_key="id")
-    params = ma.Method("serialize_params")
+    # Mandatory to declare the 'type' field due to this issue with marshmallow-sqlalchemy package:
+    # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/673
+    type = ma.auto_field(validate=[])
+    params = ma.Method(serialize="serialize_params", deserialize="deserialize_params")
 
     def serialize_params(self, obj):
         param_defs = {p["name"]: p for p in VIZ_BLOCK_CONFIG_PARAMS[obj.type]}
@@ -21,6 +24,10 @@ class VizBlockConfigSchema(ma.SQLAlchemyAutoSchema):
             rv.append(serialized_param)
         return rv
 
+    def deserialize_params(self, value):
+        # TODO: add validation on params depending on the VizBlock's type
+        return value
+
     class Meta:
         model = VizBlockConfig
 
@@ -30,6 +37,7 @@ class ReferenceTableSchema(ma.SQLAlchemyAutoSchema):
 
     class Meta:
         model = ReferenceTable
+        exclude = ["data"]
 
 
 class IndicatorSchema(ma.SQLAlchemyAutoSchema):
@@ -40,6 +48,23 @@ class IndicatorSchema(ma.SQLAlchemyAutoSchema):
         model = Indicator
         include_fk = True
         exclude = ["code"]
+
+
+class IndicatorCreationSchema(ma.SQLAlchemyAutoSchema):
+    """Schema used to validate the payload when creating an indicator.
+
+    Only the basic attributes of an indicator can be set on creation.
+    """
+
+    name = ma.String(required=True)
+    id_protocol = ma.Integer(required=True, data_key="protocolId")
+    description = ma.String(required=False)
+    reference_table_ids = ma.List(ma.Integer(), required=False, data_key="referenceTableIds")
+
+    class Meta:
+        model = Indicator
+        include_fk = True
+        fields = ("name", "description", "id_protocol", "reference_table_ids")
 
 
 class IndicatorDetailsSchema(ma.SQLAlchemyAutoSchema):

--- a/backend/calculatrice_monitoring/schemas.py
+++ b/backend/calculatrice_monitoring/schemas.py
@@ -50,7 +50,7 @@ class IndicatorSchema(ma.SQLAlchemyAutoSchema):
         exclude = ["code"]
 
 
-class IndicatorCreationSchema(ma.SQLAlchemyAutoSchema):
+class IndicatorAttributesSchema(ma.SQLAlchemyAutoSchema):
     """Schema used to validate the payload when creating an indicator.
 
     Only the basic attributes of an indicator can be set on creation.

--- a/backend/calculatrice_monitoring/tests/test_routes.py
+++ b/backend/calculatrice_monitoring/tests/test_routes.py
@@ -173,6 +173,225 @@ def test_indicators_fixture(indicators):
     assert len(indicators) == 5
 
 
+class TestCreateIndicator:
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        payload = {
+            "name": "New Indicator",
+            "description": "A brand new indicator.",
+            "protocolId": protocol.id_module,
+        }
+        response = client.post(url_for("calculatrice.create_indicator"), json=payload)
+        assert response.status_code == 201
+        assert response.json["name"] == "New Indicator"
+        assert response.json["protocolId"] == protocol.id_module
+
+        created = db.session.get(Indicator, response.json["id"])
+        assert created is not None
+        assert created.name == "New Indicator"
+        assert created.description == "A brand new indicator."
+        assert created.id_protocol == protocol.id_module
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_without_description(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        payload = {"name": "No Description", "protocolId": protocol.id_module}
+        response = client.post(url_for("calculatrice.create_indicator"), json=payload)
+        assert response.status_code == 201
+        created = db.session.get(Indicator, response.json["id"])
+        assert created.description == ""
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "users")
+    def test_create_indicator_login_required_error(self, client):
+        logout_user()
+        response = client.post(
+            url_for("calculatrice.create_indicator"), json={"name": "x", "protocolId": 1}
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_needs_create_permission_error(self, client, users, protocol):
+        # `gestionnaire` only has the R permission on CALC_ADMIN_INDICATOR, not C.
+        set_logged_user(client, users["gestionnaire"])
+        payload = {"name": "Forbidden", "protocolId": protocol.id_module}
+        response = client.post(url_for("calculatrice.create_indicator"), json=payload)
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_missing_name_error(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        response = client.post(
+            url_for("calculatrice.create_indicator"), json={"protocolId": protocol.id_module}
+        )
+        assert response.status_code == 400
+        assert "name" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_missing_protocol_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        response = client.post(
+            url_for("calculatrice.create_indicator"), json={"name": "No Protocol"}
+        )
+        assert response.status_code == 400
+        assert "protocolId" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_unknown_protocol_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        response = client.post(
+            url_for("calculatrice.create_indicator"),
+            json={"name": "Unknown protocol", "protocolId": 12345},
+        )
+        assert response.status_code == 400
+        assert "protocolId" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_unknown_field_error(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        payload = {
+            "name": "With Code",
+            "protocolId": protocol.id_module,
+            "code": "some_code = 1",
+        }
+        response = client.post(url_for("calculatrice.create_indicator"), json=payload)
+        assert response.status_code == 400
+        assert "code" in response.json
+
+
+class TestEditIndicator:
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator(self, client, users, protocols):
+        set_logged_user(client, users["admin"])
+        original_protocol = protocols["mheo_odonate_test"]
+        update_protocol = protocols["mheo_flore_test"]
+        with db.session.begin_nested():
+            indicator = Indicator(
+                name="An indicator",
+                id_protocol=original_protocol.id_module,
+                description="Description of the indicator",
+            )
+            db.session.add(indicator)
+
+        payload = {
+            "name": "Updated Indicator",
+            "description": "An updated description",
+            "protocolId": update_protocol.id_module,
+        }
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json=payload,
+        )
+
+        assert response.status_code == 200
+        assert response.json["name"] == "Updated Indicator"
+        assert response.json["description"] == "An updated description"
+        assert response.json["protocolId"] == update_protocol.id_module
+
+        assert indicator.name == "Updated Indicator"
+        assert indicator.description == "An updated description"
+        assert indicator.id_protocol == update_protocol.id_module
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_without_description(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        protocol_id = protocol_with_indicators["protocol"].id_module
+        payload = {"name": "No Description", "protocolId": protocol_id}
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json=payload,
+        )
+        assert response.status_code == 200
+        assert response.json["description"] == ""
+        assert indicator.description == ""
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "users")
+    def test_edit_indicator_login_required_error(self, client, protocol_with_indicators):
+        logout_user()
+        indicator = protocol_with_indicators["indicators"][0]
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json={"name": "x", "protocolId": 1},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_needs_update_permission_error(
+        self, client, users, protocol_with_indicators
+    ):
+        # `gestionnaire` only has the R permission on CALC_ADMIN_INDICATOR, not U.
+        set_logged_user(client, users["gestionnaire"])
+        indicator = protocol_with_indicators["indicators"][0]
+        protocol_id = protocol_with_indicators["protocol"].id_module
+        payload = {"name": "Forbidden", "protocolId": protocol_id}
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json=payload,
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_not_found_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=12345),
+            json={"name": "x", "protocolId": 1},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_missing_name_error(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        protocol_id = protocol_with_indicators["protocol"].id_module
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json={"protocolId": protocol_id},
+        )
+        assert response.status_code == 400
+        assert "name" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_missing_protocol_error(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json={"name": "No Protocol"},
+        )
+        assert response.status_code == 400
+        assert "protocolId" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_unknown_protocol_error(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json={"name": "Unknown protocol", "protocolId": 12345},
+        )
+        assert response.status_code == 400
+        assert "protocolId" in response.json
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_unknown_field_error(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        protocol_id = protocol_with_indicators["protocol"].id_module
+        payload = {
+            "name": "With Code",
+            "protocolId": protocol_id,
+            "code": "some_code = 1",
+        }
+        response = client.put(
+            url_for("calculatrice.edit_indicator", indicator_id=indicator.id_indicator),
+            json=payload,
+        )
+        assert response.status_code == 400
+        assert "code" in response.json
+
+
 class TestGetIndicatorVisualization:
     @pytest.mark.usefixtures(
         "calculatrice_permissions",
@@ -298,6 +517,119 @@ moy_durée = Moyenne(visites.durée_secondes)
         assert scalar_viz_block["data"]["figure"] == "2"
 
 
+class TestEditIndicatorCode:
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code(self, client, users, protocol_with_indicators):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        new_code = "moyenne = Moyenne(visites.duree_secondes)"
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            json={"code": new_code},
+        )
+        assert response.status_code == 204
+
+        db.session.refresh(indicator)
+        assert indicator.code == new_code
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code_handles_accented_characters(
+        self, client, users, protocol_with_indicators
+    ):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        new_code = "température_fraîche = True"
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            json={"code": new_code},
+        )
+        assert response.status_code == 204
+
+        db.session.refresh(indicator)
+        assert indicator.code == new_code
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code_handles_single_quotes(
+        self, client, users, protocol_with_indicators
+    ):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        new_code = "var = 'foo'"
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            json={"code": new_code},
+        )
+        assert response.status_code == 204
+
+        db.session.refresh(indicator)
+        assert indicator.code == new_code
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code_handles_single_quotes(
+        self, client, users, protocol_with_indicators
+    ):
+        set_logged_user(client, users["admin"])
+        indicator = protocol_with_indicators["indicators"][0]
+        new_code = 'var = "bar"'
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            json={"code": new_code},
+        )
+        assert response.status_code == 204
+
+        db.session.refresh(indicator)
+        assert indicator.code == new_code
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code_overwrites_existing_code(
+        self, client, users, protocol_with_indicators
+    ):
+        indicator = protocol_with_indicators["indicators"][0]
+        with db.session.begin_nested():
+            indicator.code = "old = 1"
+        set_logged_user(client, users["admin"])
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            json={"code": "new = 2"},
+        )
+        assert response.status_code == 204
+
+        db.session.refresh(indicator)
+        assert indicator.code == "new = 2"
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "users")
+    def test_edit_indicator_code_login_required_error(self, client, protocol_with_indicators):
+        logout_user()
+        indicator = protocol_with_indicators["indicators"][0]
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            data="moyenne = 1",
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_indicator_code_needs_update_permission_error(
+        self, client, users, protocol_with_indicators
+    ):
+        # `gestionnaire` only has the R permission on CALC_ADMIN_INDICATOR, not U.
+        set_logged_user(client, users["gestionnaire"])
+        indicator = protocol_with_indicators["indicators"][0]
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=indicator.id_indicator),
+            data="moyenne = 1",
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "protocol_with_indicators")
+    def test_edit_indicator_code_not_found_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        response = client.put(
+            url_for("calculatrice.edit_indicator_code", indicator_id=12345),
+            data="moyenne = 1",
+        )
+        assert response.status_code == 404
+
+
 class TestGetIndicatorDetails:
     @pytest.mark.usefixtures("calculatrice_permissions")
     @pytest.mark.usefixtures(
@@ -331,3 +663,153 @@ class TestGetIndicatorDetails:
         set_logged_user(client, users["gestionnaire"])
         response = client.get(url_for("calculatrice.get_indicator_details", indicator_id=12345))
         assert response.status_code == 404
+
+
+class TestEditIndicatorVizBlocks:
+    @staticmethod
+    def _create_indicator(protocol, code=""):
+        with db.session.begin_nested():
+            indicator = Indicator(
+                name="TestIndicator",
+                id_protocol=protocol.id_module,
+                description="This is the test indicator description.",
+                code=code,
+            )
+            db.session.add(indicator)
+        return indicator
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        code = "moyenne = Moyenne(visites.duree_secondes)"
+        indicator = self._create_indicator(protocol, code)
+
+        response = client.put(
+            url_for(
+                "calculatrice.update_indicator_viz_blocks", indicator_id=indicator.id_indicator
+            ),
+            json=[{"title": "foobar", "type": "bar_chart"}],
+        )
+
+        assert response.status_code == 204
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks_with_overwriting(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        indicator = self._create_indicator(protocol, code="foo=42")
+        with db.session.begin_nested():
+            vizblock1 = VizBlockConfig(title="Test old vizblock 1", type=VizBlockType.scalar)
+            indicator.viz_block_configs.append(vizblock1)
+            vizblock2 = VizBlockConfig(title="Test old vizblock 2", type=VizBlockType.bar_chart)
+            indicator.viz_block_configs.append(vizblock2)
+
+        response = client.put(
+            url_for(
+                "calculatrice.update_indicator_viz_blocks", indicator_id=indicator.id_indicator
+            ),
+            json=[{"title": "New vizblock", "type": "scalar", "params": {"variable": "bar"}}],
+        )
+
+        assert response.status_code == 204
+        assert len(indicator.viz_block_configs) == 1
+        vizblock = indicator.viz_block_configs[0]
+        assert vizblock.title == "New vizblock"
+        assert vizblock.type == VizBlockType.scalar
+        assert vizblock.params == {"variable": "bar"}
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "users")
+    def test_edit_vizblocks_login_required_error(self, client):
+        logout_user()
+        does_not_matter = 12345
+
+        response = client.put(
+            url_for("calculatrice.update_indicator_viz_blocks", indicator_id=does_not_matter),
+            json=[],
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks_needs_create_permission_error(self, client, users):
+        # `gestionnaire` only has the R permission on CALC_ADMIN_INDICATOR, not U.
+        set_logged_user(client, users["gestionnaire"])
+        does_not_matter = 12345
+
+        response = client.put(
+            url_for("calculatrice.update_indicator_viz_blocks", indicator_id=does_not_matter),
+            json=[],
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks_indicator_not_found_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        does_not_exist = 12345
+
+        response = client.put(
+            url_for("calculatrice.update_indicator_viz_blocks", indicator_id=does_not_exist),
+            json=[],
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks_list_expected_error(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        indicator = self._create_indicator(protocol)
+
+        response = client.put(
+            url_for(
+                "calculatrice.update_indicator_viz_blocks", indicator_id=indicator.id_indicator
+            ),
+            json={"title": "foobar", "type": "bar_chart"},
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_edit_vizblocks_unknown_type_error(self, client, users, protocol):
+        set_logged_user(client, users["admin"])
+        indicator = self._create_indicator(protocol)
+        unknown_type = "unknown_enum_value"
+
+        response = client.put(
+            url_for(
+                "calculatrice.update_indicator_viz_blocks", indicator_id=indicator.id_indicator
+            ),
+            json=[{"title": "foobar", "type": unknown_type}],
+        )
+
+        assert response.status_code == 400
+        assert "type" in response.json["description"]
+
+
+class TestGetRerenceTables:
+    @pytest.mark.usefixtures("calculatrice_permissions", "reference_tables")
+    def test_get_reftables(self, client, users):
+        set_logged_user(client, users["gestionnaire"])
+        response = client.get(url_for("calculatrice.get_reference_tables"))
+        assert response.status_code == 200
+
+        reftables_codes = [rt["code"] for rt in response.json]
+        assert len(reftables_codes) == 2
+        assert "indices_he" in reftables_codes
+        assert "indices_ht" in reftables_codes
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_get_empty_reftables_list(self, client, users):
+        set_logged_user(client, users["gestionnaire"])
+        response = client.get(url_for("calculatrice.get_reference_tables"))
+        assert response.status_code == 200
+        assert response.json == []
+
+    def test_error_endpoint_requires_login(self, client):
+        logout_user()
+        response = client.get(url_for("calculatrice.get_reference_tables"))
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_get_protocol_needs_permission_error(self, client, users):
+        set_logged_user(client, users["public"])
+        response = client.get(url_for("calculatrice.get_reference_tables"))
+        assert response.status_code == 403

--- a/backend/calculatrice_monitoring/tests/test_utils.py
+++ b/backend/calculatrice_monitoring/tests/test_utils.py
@@ -1,0 +1,33 @@
+from ..utils import extract_variable_names
+
+
+class TestExtractVariableNames:
+    def test_it_with_one_variable(self):
+        code = "foo=1"
+        names = extract_variable_names(code)
+        assert len(names) == 1
+        name = names[0]
+        assert name == "foo"
+
+    def test_it_with_multiple_variables(self):
+        code = """
+foo=1
+bar=2
+"""
+        names = extract_variable_names(code)
+        assert len(names) == 2
+        assert "foo" in names
+        assert "bar" in names
+
+    def test_it_with_no_variable(self):
+        code = """
+def foo():
+    print("bar")
+        """
+        names = extract_variable_names(code)
+        assert len(names) == 0
+
+    def test_it_with_syntactically_incorrect_code(self):
+        code = "foo bar"
+        names = extract_variable_names(code)
+        assert len(names) == 0

--- a/backend/calculatrice_monitoring/utils.py
+++ b/backend/calculatrice_monitoring/utils.py
@@ -1,0 +1,14 @@
+import ast
+
+
+def extract_variable_names(code: str) -> list[str]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    names = []
+    for node in ast.walk(tree):
+        if type(node) is ast.Assign:
+            names.append(node.targets[0].id)
+    return names

--- a/frontend/app/components/indicator-code-editor/indicator-code-editor.component.css
+++ b/frontend/app/components/indicator-code-editor/indicator-code-editor.component.css
@@ -1,0 +1,5 @@
+form div {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/frontend/app/components/indicator-code-editor/indicator-code-editor.component.html
+++ b/frontend/app/components/indicator-code-editor/indicator-code-editor.component.html
@@ -1,0 +1,42 @@
+<div
+  *ngIf="indicator"
+  class="container"
+>
+  <a
+    mat-raised-button
+    routerLink="/calculatrice"
+    class="mb-2"
+  >
+    <mat-icon>chevron_left</mat-icon>
+    Retour
+  </a>
+  <div class="card">
+    <div class="card-header">
+      <h2>Indicateur: {{ indicator.name }}</h2>
+    </div>
+    <div class="card-body">
+      <form
+        [formGroup]="indicatorForm"
+        (ngSubmit)="onSubmit()"
+      >
+        <div>
+          <label for="code">Code de l'indicateur</label>
+          <textarea
+            id="code"
+            formControlName="code"
+            rows="10"
+            cols="80"
+          ></textarea>
+        </div>
+        <hr />
+        <button
+          type="submit"
+          class="btn btn-success"
+          [disabled]="!indicatorForm.valid"
+        >
+          Suivant
+        </button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/indicator-code-editor/indicator-code-editor.component.ts
+++ b/frontend/app/components/indicator-code-editor/indicator-code-editor.component.ts
@@ -1,0 +1,50 @@
+import { HttpResponse } from '@angular/common/http';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { catchError } from 'rxjs/operators';
+import { IndicatorDetails } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+import { UtilsService } from '../../services/utils.service';
+
+@Component({
+  selector: 'pnx-calc-indicator-code-editor',
+  templateUrl: './indicator-code-editor.component.html',
+  styleUrls: ['./indicator-code-editor.component.css'],
+})
+export class IndicatorCodeEditorComponent implements OnInit {
+  indicatorForm: FormGroup;
+  indicator: IndicatorDetails;
+
+  constructor(
+    private _data: DataService,
+    private _formBuilder: FormBuilder,
+    private _route: ActivatedRoute,
+    private _router: Router,
+    private _utils: UtilsService
+  ) {
+    this.indicatorForm = this._formBuilder.group({
+      code: [''],
+    });
+  }
+
+  ngOnInit() {
+    this._route.params.subscribe((params) => {
+      this._data.getIndicatorDetails(params.indicatorId).subscribe((data: IndicatorDetails) => {
+        this.indicator = data;
+        this.indicatorForm.controls.code.setValue(data.code);
+      });
+    });
+  }
+
+  onSubmit() {
+    if (this.indicatorForm.valid) {
+      this._data
+        .editIndicatorCode(this.indicator.id, this.indicatorForm.value.code)
+        .pipe(catchError(this._utils.handleError))
+        .subscribe((data: HttpResponse<String>) => {
+          this._router.navigate(['/calculatrice/indicator', this.indicator.id, 'viz-blocks']);
+        });
+    }
+  }
+}

--- a/frontend/app/components/indicator-form/indicator-form.component.css
+++ b/frontend/app/components/indicator-form/indicator-form.component.css
@@ -1,0 +1,14 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-element {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-element label {
+  margin-bottom: 0.2rem;
+}

--- a/frontend/app/components/indicator-form/indicator-form.component.html
+++ b/frontend/app/components/indicator-form/indicator-form.component.html
@@ -1,0 +1,79 @@
+<div
+  *ngIf="mode"
+  class="container"
+>
+  <a
+    mat-raised-button
+    routerLink="/calculatrice"
+    class="mb-2"
+  >
+    <mat-icon>chevron_left</mat-icon>
+    Retour
+  </a>
+  <div class="card">
+    <div class="card-header">
+      <h2>{{ mode === 'create' ? 'Créer un indicateur' : "Éditer l'indicateur" }}</h2>
+    </div>
+    <div class="card-body">
+      <form
+        [formGroup]="indicatorForm"
+        (ngSubmit)="onSubmit()"
+      >
+        <div class="form-container">
+          <div class="form-element">
+            <label for="name">Nom</label>
+            <input
+              id="name"
+              type="text"
+              formControlName="name"
+              class="form-control"
+              required
+            />
+          </div>
+          <div class="form-element">
+            <label for="description">Description</label>
+            <textarea
+              id="description"
+              formControlName="description"
+              class="form-control"
+            ></textarea>
+          </div>
+          <div class="form-element">
+            <label [for]="protocol">Protocole</label>
+            <ng-select
+              #protocol
+              id="protocol"
+              [items]="protocols"
+              bindLabel="label"
+              bindValue="id"
+              placeholder="Sélectionner un protocole"
+              formControlName="protocolId"
+              required
+            ></ng-select>
+          </div>
+          <div class="form-element">
+            <label [for]="referenceTablesSelect">Tables de référence</label>
+            <ng-select
+              #referenceTablesSelect
+              id="referenceTables"
+              [items]="referenceTables"
+              [multiple]="true"
+              bindLabel="name"
+              bindValue="id"
+              placeholder="Sélectionner des tables de référence"
+              formControlName="referenceTableIds"
+            ></ng-select>
+          </div>
+        </div>
+        <hr />
+        <button
+          type="submit"
+          class="btn btn-success"
+          [disabled]="!indicatorForm.valid"
+        >
+          Suivant
+        </button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/indicator-form/indicator-form.component.ts
+++ b/frontend/app/components/indicator-form/indicator-form.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { catchError } from 'rxjs/operators';
+import { Indicator, IndicatorDetails, Protocol, ReferenceTable } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+import { UtilsService } from '../../services/utils.service';
+
+@Component({
+  selector: 'pnx-calc-indicator-form',
+  templateUrl: './indicator-form.component.html',
+  styleUrls: ['./indicator-form.component.css'],
+})
+export class IndicatorFormComponent implements OnInit {
+  indicatorForm: FormGroup;
+  protocols: Array<Protocol> = undefined;
+  referenceTables: Array<ReferenceTable> = undefined;
+  indicatorDetails: IndicatorDetails;
+  mode?: 'create' | 'edit';
+
+  constructor(
+    private _data: DataService,
+    private _formBuilder: FormBuilder,
+    private _router: Router,
+    private _utils: UtilsService,
+    private _route: ActivatedRoute
+  ) {
+    this.indicatorForm = this._formBuilder.group({
+      name: ['', { nonNullable: true }],
+      description: [''],
+      protocolId: ['', { nonNullable: true }],
+      referenceTableIds: [[]],
+    });
+  }
+
+  ngOnInit() {
+    this._data.getProtocols({}).subscribe((data: Array<Protocol>) => {
+      this.protocols = data;
+    });
+    this._data.getReferenceTables().subscribe((data: Array<ReferenceTable>) => {
+      this.referenceTables = data;
+    });
+    this._route.params.subscribe((params) => {
+      if (params.indicatorId === undefined) {
+        this.mode = 'create';
+        return;
+      }
+      this.mode = 'edit';
+      const indicatorId: number = params.indicatorId;
+      this._data.getIndicatorDetails(indicatorId).subscribe((data: IndicatorDetails) => {
+        this.indicatorDetails = data;
+        this.indicatorForm.setValue({
+          name: data.name,
+          description: data.description,
+          protocolId: data.protocol.id,
+          referenceTableIds: data.referenceTables.map((referenceTable) => referenceTable.id),
+        });
+      });
+    });
+  }
+
+  onSubmit() {
+    if (this.indicatorForm.valid) {
+      if (this.mode === 'create') {
+        this._data
+          .createIndicator(this.indicatorForm.value)
+          .pipe(catchError(this._utils.handleError))
+          .subscribe((data: Indicator) => {
+            this._router.navigate(['/calculatrice/indicator', data.id, 'edit-code']);
+          });
+      } else {
+        this._data
+          .editIndicator(this.indicatorDetails.id, this.indicatorForm.value)
+          .pipe(catchError(this._utils.handleError))
+          .subscribe((data: Indicator) => {
+            this._router.navigate(['/calculatrice/indicator', data.id, 'edit-code']);
+          });
+      }
+    }
+  }
+}

--- a/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.css
+++ b/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.css
@@ -1,0 +1,19 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-element {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-element label {
+  margin-bottom: 0.2rem;
+}
+
+.invalid-variable {
+  color: red;
+  border-color: red;
+}

--- a/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.html
+++ b/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.html
@@ -1,0 +1,51 @@
+<div>
+  <strong>Paramètres bloc BarChart</strong>
+  <div
+    [formGroup]="form"
+    class="form-container"
+  >
+    <div class="form-element">
+      <label for="variable">Variable:</label>
+      <select
+        id="variable"
+        formControlName="variable"
+        required
+        class="form-control"
+        [class.invalid-variable]="variableControl?.hasError('unknownVariable')"
+      >
+        <option
+          *ngFor="let variable of variableOptions"
+          [disabled]="!variableValueIsValid(variable)"
+          value="{{ variable }}"
+        >
+          {{ variable }}
+        </option>
+      </select>
+      <span
+        *ngIf="variableControl?.hasError('unknownVariable')"
+        class="invalid-variable"
+      >
+        Cette variable n'existe plus dans le code de l'indicateur.
+      </span>
+    </div>
+    <div class="form-element">
+      <label for="entity_prop">entity_prop:</label>
+      <input
+        id="entity_prop"
+        formControlName="entity_prop"
+        type="text"
+        required
+        class="form-control"
+      />
+    </div>
+    <div class="form-element">
+      <label for="dataset_label">dataset_label:</label>
+      <input
+        id="dataset_label"
+        formControlName="dataset_label"
+        type="text"
+        class="form-control"
+      />
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.ts
+++ b/frontend/app/components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component.ts
@@ -1,0 +1,74 @@
+import { Component, Input } from '@angular/core';
+import { AbstractControl, FormControl, FormGroup, ValidationErrors } from '@angular/forms';
+import { VisualizationBlockConfigParam } from '../../../interfaces';
+
+@Component({
+  selector: 'pnx-calc-bar-chart-viz-block-form',
+  templateUrl: './bar-chart-viz-block-form.component.html',
+  styleUrls: ['./bar-chart-viz-block-form.component.css'],
+})
+export class BarChartVizBlockFormComponent {
+  @Input() public form: FormGroup;
+  @Input() public variables: string[];
+  @Input() public params?: VisualizationBlockConfigParam[];
+
+  /**
+   * Construit le groupe de contrôles des paramètres du bloc.
+   * Appelé par le composant parent avant que le formulaire ne soit affiché, pour
+   * que la validité du formulaire ne change pas pendant la détection de changements.
+   * `getVariables` est évalué à chaque validation car la liste des variables est
+   * chargée de façon asynchrone et peut ne pas être disponible ici.
+   */
+  static buildForm(
+    params: VisualizationBlockConfigParam[] | undefined,
+    getVariables: () => string[]
+  ): FormGroup {
+    return new FormGroup({
+      variable: new FormControl(this.getParamValue(params, 'variable') || '', {
+        nonNullable: true,
+        validators: (control) => this.validateVariable(control, getVariables()),
+      }),
+      entity_prop: new FormControl(this.getParamValue(params, 'entity_prop') || '', {
+        nonNullable: true,
+      }),
+      dataset_label: new FormControl(this.getParamValue(params, 'dataset_label') || ''),
+    });
+  }
+
+  private static getParamValue(params: VisualizationBlockConfigParam[] | undefined, paramName) {
+    return params?.find((elmt) => elmt.name === paramName)?.value;
+  }
+
+  private static isVariableValid(value, variables: string[] | undefined) {
+    return variables?.find((elmt) => elmt === value) !== undefined;
+  }
+
+  private static validateVariable(
+    control: AbstractControl,
+    variables: string[] | undefined
+  ): ValidationErrors | null {
+    return this.isVariableValid(control.value, variables)
+      ? null
+      : { unknownVariable: control.value };
+  }
+
+  get variableControl() {
+    return this.form.get('variable');
+  }
+
+  variableValueIsValid(value) {
+    return BarChartVizBlockFormComponent.isVariableValid(value, this.variables);
+  }
+
+  get variableOptions() {
+    if (this.variables === undefined) {
+      return undefined;
+    }
+    let variableOpts = this.variables.slice();
+    let variableStoredValue = BarChartVizBlockFormComponent.getParamValue(this.params, 'variable');
+    if (variableStoredValue !== undefined && !this.variableValueIsValid(variableStoredValue)) {
+      variableOpts.push(variableStoredValue);
+    }
+    return variableOpts;
+  }
+}

--- a/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.css
+++ b/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.css
@@ -1,0 +1,12 @@
+.action-buttons {
+  display: flex;
+  justify-content: end;
+  margin-bottom: 1rem;
+}
+
+.vizblock-action-buttons {
+  display: flex;
+  justify-content: end;
+  margin-bottom: 0.2rem;
+  gap: 0.5rem;
+}

--- a/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.html
+++ b/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.html
@@ -1,0 +1,73 @@
+<div class="container">
+  <a
+    mat-raised-button
+    routerLink="/calculatrice"
+    class="mb-2"
+  >
+    <mat-icon>chevron_left</mat-icon>
+    Retour
+  </a>
+  <div class="card">
+    <div class="card-header">
+      <h2>Éditer les blocs de visualisation</h2>
+    </div>
+    <div class="card-body">
+      <div class="action-buttons">
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="addVizBlockForm()"
+        >
+          + Ajouter un bloc
+        </button>
+      </div>
+      <form
+        [formGroup]="form"
+        (ngSubmit)="onSubmit()"
+      >
+        <div formArrayName="vizBlocks">
+          <div
+            *ngFor="let vizBlock of vizBlocks.controls; let i = index"
+            class="mb-3 p-3 border rounded"
+          >
+            <div class="vizblock-action-buttons">
+              <button
+                type="button"
+                class="btn btn-primary btn-sm"
+              >
+                Dépl. haut
+              </button>
+              <button
+                type="button"
+                class="btn btn-primary btn-sm"
+              >
+                Dépl. bas
+              </button>
+              <button
+                *ngIf="vizBlocks.controls.length > 0"
+                type="button"
+                class="btn btn-danger btn-sm"
+                (click)="removeVizBlock(i)"
+              >
+                Supprimer
+              </button>
+            </div>
+            <pnx-calc-viz-block-form
+              [form]="vizBlock"
+              [variables]="variables"
+              [vizBlock]="indicatorDetails.visualizationBlockConfigs[i]"
+            ></pnx-calc-viz-block-form>
+          </div>
+          <hr />
+          <button
+            type="submit"
+            [disabled]="!form.valid"
+            class="btn btn-success"
+          >
+            Valider
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.ts
+++ b/frontend/app/components/indicator-viz-blocks-form/indicator-viz-blocks-form.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit } from '@angular/core';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { HttpResponse } from '@librairies/@angular/common/http';
+import { IndicatorDetails } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+import { VizBlockFormComponent } from './viz-block-form/viz-block-form.component';
+
+@Component({
+  selector: 'pnx-calc-indicator-viz-blocks-form',
+  templateUrl: './indicator-viz-blocks-form.component.html',
+  styleUrls: ['./indicator-viz-blocks-form.component.css'],
+})
+export class IndicatorVizBlocksFormComponent implements OnInit {
+  form: FormGroup;
+  indicatorDetails: IndicatorDetails;
+  variables: string[];
+
+  constructor(
+    private _route: ActivatedRoute,
+    private _data: DataService,
+    private _router: Router
+  ) {
+    this.form = new FormGroup({
+      vizBlocks: new FormArray([]),
+    });
+  }
+
+  get vizBlocks() {
+    return this.form.controls.vizBlocks as FormArray<FormGroup>;
+  }
+
+  addVizBlockForm() {
+    this.vizBlocks.push(VizBlockFormComponent.buildForm(null, () => this.variables));
+    this.indicatorDetails.visualizationBlockConfigs.push(null);
+  }
+
+  removeVizBlock(index: number) {
+    this.vizBlocks.removeAt(index);
+    this.indicatorDetails.visualizationBlockConfigs.splice(index, 1);
+  }
+
+  initVizBlocksForm() {
+    this.indicatorDetails.visualizationBlockConfigs.forEach((config) => {
+      this.vizBlocks.push(VizBlockFormComponent.buildForm(config, () => this.variables));
+    });
+    if (this.indicatorDetails.visualizationBlockConfigs.length === 0) this.addVizBlockForm();
+  }
+
+  /**
+   * Les validateurs des contrôles "variable" dépendent de `variables`, chargée
+   * de façon asynchrone : il faut relancer la validation quand la liste arrive.
+   */
+  private revalidateForm(control: AbstractControl = this.form) {
+    if (control instanceof FormGroup) {
+      Object.values(control.controls).forEach((child) => this.revalidateForm(child));
+    } else if (control instanceof FormArray) {
+      control.controls.forEach((child) => this.revalidateForm(child));
+    } else {
+      // TODO: check if the above is necessary => should not updateValueAndValidity check the children?
+      control.updateValueAndValidity({ emitEvent: false });
+    }
+  }
+
+  ngOnInit(): void {
+    this._route.params.subscribe((params) => {
+      this._data.getIndicatorDetails(params.indicatorId).subscribe((data: IndicatorDetails) => {
+        this.indicatorDetails = data;
+        this.initVizBlocksForm();
+      });
+    });
+    this._route.params.subscribe((params) => {
+      this._data.getIndicatorCodeVariables(params.indicatorId).subscribe((data: string[]) => {
+        this.variables = data;
+        this.revalidateForm();
+      });
+    });
+  }
+
+  onSubmit() {
+    if (this.form.valid) {
+      this._data
+        .updateIndicatorVizBlocks(this.indicatorDetails.id, this.form.value.vizBlocks)
+        .subscribe((data: HttpResponse<String>) => {
+          this._router.navigate(['/calculatrice/indicator', this.indicatorDetails.id, 'details']);
+        });
+    }
+  }
+}

--- a/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.css
+++ b/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.css
@@ -1,0 +1,21 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-element {
+  display: flex;
+  flex-direction: row;
+  /*flex-direction: column;*/
+  gap: 1rem;
+}
+
+.form-element label {
+  margin-bottom: 0.2rem;
+}
+
+.invalid-variable {
+  color: red;
+  border-color: red;
+}

--- a/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.html
+++ b/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.html
@@ -1,0 +1,32 @@
+<div>
+  <strong>Paramètres bloc Scalaire :</strong>
+  <div
+    [formGroup]="form"
+    class="form-container"
+  >
+    <div class="form-element">
+      <label for="variable">Variable:</label>
+      <select
+        id="variable"
+        formControlName="variable"
+        required
+        class="form-control"
+        [class.invalid-variable]="variableControl?.hasError('unknownVariable')"
+      >
+        <option
+          *ngFor="let variable of variableOptions"
+          [disabled]="!variableValueIsValid(variable)"
+          value="{{ variable }}"
+        >
+          {{ variable }}
+        </option>
+      </select>
+      <span
+        *ngIf="variableControl?.hasError('unknownVariable')"
+        class="invalid-variable"
+      >
+        Cette variable n'existe plus dans le code de l'indicateur.
+      </span>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.ts
+++ b/frontend/app/components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component.ts
@@ -1,0 +1,70 @@
+import { Component, Input } from '@angular/core';
+import { AbstractControl, FormControl, FormGroup, ValidationErrors } from '@angular/forms';
+import { VisualizationBlockConfigParam } from '../../../interfaces';
+
+@Component({
+  selector: 'pnx-calc-scalar-viz-block-form',
+  templateUrl: './scalar-viz-block-form.component.html',
+  styleUrls: ['./scalar-viz-block-form.component.css'],
+})
+export class ScalarVizBlockFormComponent {
+  @Input() public form: FormGroup;
+  @Input() public variables: string[];
+  @Input() public params?: VisualizationBlockConfigParam[];
+
+  /**
+   * Construit le groupe de contrôles des paramètres du bloc.
+   * Appelé par le composant parent avant que le formulaire ne soit affiché, pour
+   * que la validité du formulaire ne change pas pendant la détection de changements.
+   * `getVariables` est évalué à chaque validation car la liste des variables est
+   * chargée de façon asynchrone et peut ne pas être disponible ici.
+   */
+  static buildForm(
+    params: VisualizationBlockConfigParam[] | undefined,
+    getVariables: () => string[]
+  ): FormGroup {
+    return new FormGroup({
+      variable: new FormControl(this.getParamValue(params, 'variable') || '', {
+        nonNullable: true,
+        validators: (control) => this.validateVariable(control, getVariables()),
+      }),
+    });
+  }
+
+  private static getParamValue(params: VisualizationBlockConfigParam[] | undefined, paramName) {
+    return params?.find((elmt) => elmt.name === paramName)?.value;
+  }
+
+  private static isVariableValid(value, variables: string[] | undefined) {
+    return variables?.find((elmt) => elmt === value) !== undefined;
+  }
+
+  private static validateVariable(
+    control: AbstractControl,
+    variables: string[] | undefined
+  ): ValidationErrors | null {
+    return this.isVariableValid(control.value, variables)
+      ? null
+      : { unknownVariable: control.value };
+  }
+
+  get variableControl() {
+    return this.form.get('variable');
+  }
+
+  variableValueIsValid(value) {
+    return ScalarVizBlockFormComponent.isVariableValid(value, this.variables);
+  }
+
+  get variableOptions() {
+    if (this.variables === undefined) {
+      return undefined;
+    }
+    let variableOpts = this.variables.slice();
+    let variableStoredValue = ScalarVizBlockFormComponent.getParamValue(this.params, 'variable');
+    if (variableStoredValue !== undefined && !this.variableValueIsValid(variableStoredValue)) {
+      variableOpts.push(variableStoredValue);
+    }
+    return variableOpts;
+  }
+}

--- a/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.css
+++ b/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.css
@@ -1,0 +1,18 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-element {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-element label {
+  margin-bottom: 0.2rem;
+}
+
+.block-params {
+  margin-left: 3rem;
+}

--- a/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.html
+++ b/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.html
@@ -1,0 +1,60 @@
+<div
+  [formGroup]="form"
+  class="form-container"
+>
+  <div class="form-element">
+    <label for="title">Titre</label>
+    <input
+      id="title"
+      formControlName="title"
+      type="text"
+      class="form-control form-control-sm"
+    />
+  </div>
+  <div class="form-element">
+    <label for="information">Information</label>
+    <input
+      id="information"
+      formControlName="info"
+      type="text"
+    />
+  </div>
+  <div class="form-element">
+    <label for="description">Description</label>
+    <textarea
+      id="description"
+      formControlName="description"
+      type="text"
+    ></textarea>
+  </div>
+  <div class="form-element">
+    <label for="type">Type :</label>
+    <select
+      id="type"
+      formControlName="type"
+      (change)="onTypeChange($event)"
+      required
+      class="form-control"
+    >
+      <option value="bar_chart">Bar chart</option>
+      <option value="scalar">Scalaire</option>
+    </select>
+  </div>
+  <div
+    class="block-params"
+    [ngSwitch]="form.value.type"
+  >
+    <pnx-calc-bar-chart-viz-block-form
+      *ngSwitchCase="'bar_chart'"
+      [form]="paramsForm"
+      [variables]="variables"
+      [params]="vizBlock?.params"
+    ></pnx-calc-bar-chart-viz-block-form>
+    <pnx-calc-scalar-viz-block-form
+      *ngSwitchCase="'scalar'"
+      [form]="paramsForm"
+      [variables]="variables"
+      [params]="vizBlock?.params"
+    ></pnx-calc-scalar-viz-block-form>
+  </div>
+</div>

--- a/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.ts
+++ b/frontend/app/components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component.ts
@@ -1,0 +1,75 @@
+import { Component, Input } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+  VisualizationBlockConfig,
+  VisualizationBlockConfigDetails,
+  VisualizationBlockConfigParam,
+} from '../../../interfaces';
+import { BarChartVizBlockFormComponent } from '../bar-chart-viz-block-form/bar-chart-viz-block-form.component';
+import { ScalarVizBlockFormComponent } from '../scalar-viz-block-form/scalar-viz-block-form.component';
+
+@Component({
+  selector: 'pnx-calc-viz-block-form',
+  templateUrl: './viz-block-form.component.html',
+  styleUrls: ['./viz-block-form.component.css'],
+})
+export class VizBlockFormComponent {
+  @Input() form: FormGroup;
+  @Input() variables: string[];
+  @Input() vizBlock?: VisualizationBlockConfigDetails;
+
+  /**
+   * Construit le groupe de contrôles d'un bloc de visualisation.
+   * Appelé par le composant parent au moment où le bloc est ajouté au FormArray :
+   * le formulaire doit être complet (validateurs compris) avant d'être affiché,
+   * sinon sa validité change pendant la détection de changements.
+   */
+  // TODO: essayer de juste passer la liste des variables plutôt qu'une fonction
+  static buildForm(
+    config: VisualizationBlockConfigDetails | undefined,
+    getVariables: () => string[]
+  ): FormGroup {
+    return new FormGroup({
+      title: new FormControl(config?.title || '', { validators: Validators.required }),
+      info: new FormControl(config?.info || ''),
+      description: new FormControl(config?.description || ''),
+      type: new FormControl(config?.type || '', {
+        nonNullable: true,
+        validators: Validators.required,
+      }),
+      params: this.buildParamsForm(config?.type, config?.params, getVariables),
+    });
+  }
+
+  private static buildParamsForm(
+    type: VisualizationBlockConfig['type'] | undefined,
+    params: VisualizationBlockConfigParam[] | undefined,
+    getVariables: () => string[]
+  ): FormGroup {
+    switch (type) {
+      case 'bar_chart':
+        return BarChartVizBlockFormComponent.buildForm(params, getVariables);
+      case 'scalar':
+        return ScalarVizBlockFormComponent.buildForm(params, getVariables);
+      default:
+        return new FormGroup({});
+    }
+  }
+
+  get paramsForm() {
+    return this.form.controls.params as FormGroup;
+  }
+
+  onTypeChange(event: Event) {
+    const type = (event.target as HTMLSelectElement).value as VisualizationBlockConfig['type'];
+    if (this.vizBlock?.params !== undefined) {
+      this.vizBlock.params = [];
+    }
+    // Le groupe des paramètres est reconstruit ici, depuis le gestionnaire
+    // d'événement, et non par le composant enfant affiché par le ngSwitch.
+    this.form.setControl(
+      'params',
+      VizBlockFormComponent.buildParamsForm(type, this.vizBlock?.params, () => this.variables)
+    );
+  }
+}

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -9,7 +9,13 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule, Routes } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 import { NgChartsModule } from 'ng2-charts';
+import { IndicatorCodeEditorComponent } from './components/indicator-code-editor/indicator-code-editor.component';
 import { IndicatorDetailsComponent } from './components/indicator-details/indicator-details.component';
+import { IndicatorFormComponent } from './components/indicator-form/indicator-form.component';
+import { BarChartVizBlockFormComponent } from './components/indicator-viz-blocks-form/bar-chart-viz-block-form/bar-chart-viz-block-form.component';
+import { IndicatorVizBlocksFormComponent } from './components/indicator-viz-blocks-form/indicator-viz-blocks-form.component';
+import { ScalarVizBlockFormComponent } from './components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component';
+import { VizBlockFormComponent } from './components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component';
 import { ModuleComponent } from './components/module/module.component';
 import { VisualizationBlockComponent } from './components/visualization-block/visualization-block.component';
 import { VisualizationChartComponent } from './components/visualization-chart/visualization-chart.component';
@@ -17,10 +23,15 @@ import { VisualizationPageComponent } from './components/visualization-page/visu
 import { VisualizationParamsFormComponent } from './components/visualization-params-form/visualization-params-form.component';
 import { VisualizationScalarComponent } from './components/visualization-scalar/visualization-scalar.component';
 import { DataService } from './services/data.service';
+import { UtilsService } from './services/utils.service';
 
 const routes: Routes = [
   { path: '', component: ModuleComponent },
   { path: 'indicator/:indicatorId/details', component: IndicatorDetailsComponent },
+  { path: 'indicator/create', component: IndicatorFormComponent },
+  { path: 'indicator/:indicatorId/edit', component: IndicatorFormComponent },
+  { path: 'indicator/:indicatorId/edit-code', component: IndicatorCodeEditorComponent },
+  { path: 'indicator/:indicatorId/viz-blocks', component: IndicatorVizBlocksFormComponent },
   { path: 'visualization/:indicatorId/params', component: VisualizationParamsFormComponent },
   { path: 'visualization/:indicatorId', component: VisualizationPageComponent },
 ];
@@ -29,6 +40,12 @@ const routes: Routes = [
   declarations: [
     ModuleComponent,
     IndicatorDetailsComponent,
+    IndicatorFormComponent,
+    IndicatorCodeEditorComponent,
+    IndicatorVizBlocksFormComponent,
+    VizBlockFormComponent,
+    ScalarVizBlockFormComponent,
+    BarChartVizBlockFormComponent,
     VisualizationParamsFormComponent,
     VisualizationPageComponent,
     VisualizationBlockComponent,
@@ -47,7 +64,7 @@ const routes: Routes = [
     GN2CommonModule,
     NgChartsModule,
   ],
-  providers: [DataService],
+  providers: [DataService, UtilsService],
   bootstrap: [ModuleComponent],
 })
 export class GeonatureModule {}

--- a/frontend/app/interfaces.ts
+++ b/frontend/app/interfaces.ts
@@ -11,8 +11,15 @@ export interface IndicatorDetails {
   description: string;
   protocol: Protocol;
   code: string;
-  visualizationBlockConfigs: VisualizationBlockConfig[];
+  visualizationBlockConfigs: VisualizationBlockConfigDetails[];
   referenceTables: ReferenceTable[];
+}
+
+export interface IndicatorAttributes {
+  name: string;
+  description: string;
+  protocolId: number;
+  referenceTableIds: number[];
 }
 
 export interface Protocol {
@@ -31,8 +38,15 @@ export interface VisualizationBlockConfig {
   title: string;
   info: string;
   description: string;
-  type: 'scalaire' | 'barChart';
+  type: 'scalar' | 'bar_chart';
+}
+
+export interface VisualizationBlockConfigDetails extends VisualizationBlockConfig {
   params: VisualizationBlockConfigParam[];
+}
+
+export interface VisualizationBlockConfigPayload extends VisualizationBlockConfig {
+  params: { [key: string]: string };
 }
 
 export interface VisualizationBlockConfigParam {

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from '@geonature/services/config.service';
 import { ParamsDict } from '@geonature_common/form/data-form.service';
@@ -6,10 +6,13 @@ import { from } from 'rxjs';
 import {
   Campaign,
   Indicator,
+  IndicatorAttributes,
   IndicatorDetails,
   Protocol,
+  ReferenceTable,
   Site,
   SitesGroup,
+  VisualizationBlockConfigPayload,
   VisualizationBlockDefinition,
 } from '../interfaces';
 
@@ -59,6 +62,42 @@ export class DataService {
     });
   }
 
+  createIndicator(indicatorAttributes: IndicatorAttributes) {
+    return this._http.post<Indicator>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator`,
+      indicatorAttributes
+    );
+  }
+
+  editIndicator(indicatorId: Number, indicatorAttributes: IndicatorAttributes) {
+    return this._http.put<Indicator>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}`,
+      indicatorAttributes
+    );
+  }
+
+  editIndicatorCode(indicatorId: Number, code: String) {
+    return this._http.put<HttpResponse<String>>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}/code`,
+      { code: code },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  updateIndicatorVizBlocks(
+    indicatorId: Number,
+    vizBlocksConfig: VisualizationBlockConfigPayload[]
+  ) {
+    return this._http.put<HttpResponse<String>>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}/viz-blocks`,
+      vizBlocksConfig,
+      {
+        headers: { 'Content-Type': 'application/json' },
+        responseType: 'json',
+      }
+    );
+  }
+
   getIndicator(indicatorId: number) {
     return this._http.get<Indicator>(
       `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}`
@@ -68,6 +107,12 @@ export class DataService {
   getIndicatorDetails(indicatorId: number) {
     return this._http.get<IndicatorDetails>(
       `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}/details`
+    );
+  }
+
+  getIndicatorCodeVariables(indicatorId: number) {
+    return this._http.get<string[]>(
+      `${this._config.API_ENDPOINT}/calculatrice/indicator/${indicatorId}/code-variables`
     );
   }
 
@@ -141,6 +186,12 @@ export class DataService {
         })),
         viz_type: visualizationType,
       }
+    );
+  }
+
+  getReferenceTables() {
+    return this._http.get<Array<ReferenceTable>>(
+      `${this._config.API_ENDPOINT}/calculatrice/reftables`
     );
   }
 

--- a/frontend/app/services/utils.service.ts
+++ b/frontend/app/services/utils.service.ts
@@ -1,0 +1,18 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+
+@Injectable()
+export class UtilsService {
+  handleError(error: HttpErrorResponse) {
+    if (error.status === 0) {
+      // A client-side or network error occurred. Handle it accordingly.
+      console.error('An error occurred:', error.error);
+    } else {
+      // The backend returned an unsuccessful response code.
+      // The response body may contain clues as to what went wrong.
+      console.error(`Backend returned code ${error.status}, body was: `, error.error);
+    }
+    return throwError(() => error);
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "globals": "^16.3.0",
         "prettier": "~3.3.3",
         "prettier-plugin-organize-imports": "^4.2.0",
+        "rxjs": "~6.6.3",
         "typescript-eslint": "^8.42.0"
       }
     },
@@ -2376,6 +2377,23 @@
         }
       }
     },
+    "node_modules/listr2/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/listr2/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2972,12 +2990,16 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -3319,10 +3341,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5167,6 +5190,23 @@
         "rxjs": "^7.5.1",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.8.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+          "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -5564,12 +5604,12 @@
       }
     },
     "rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -5799,9 +5839,9 @@
       "requires": {}
     },
     "tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tunnel-agent": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "globals": "^16.3.0",
     "prettier": "~3.3.3",
     "prettier-plugin-organize-imports": "^4.2.0",
-    "typescript-eslint": "^8.42.0"
+    "typescript-eslint": "^8.42.0",
+    "rxjs": "~6.6.3"
   }
 }


### PR DESCRIPTION
Issues: #21 , #22 , #23 

**Description**

Ajoute une succession de trois pages formulaires pour créer/éditer les indicateurs.

1. saisie des attributs basiques (nom, protocole, ...) et des tableaux de référence utilisés
2. saisie du code de l'indicateur (pour l'instant un simple `<textarea>`)
3. configuration des blocs de visualisation

**Points non implémentés pour le moment**

- validation backend complète pour les config de vizblock (les paramètres du vizblock type !)
- reprendre le fetch des multiples éléments pour le form 1, synchroniser, afficher la page uniquement quand tout est prêt
- garder les routes des nouvelles pages avec une vérification des permissions
- permettre d'ordonner les vizblocks (boutons placeholders « Dépl. haut/bas » pour l'instant)
- statut de publication (_edit_)



