### PR TITLE
feat: add reftables pages (#24)

### DIFF
--- a/backend/calculatrice_monitoring/blueprint.py
+++ b/backend/calculatrice_monitoring/blueprint.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, abort, request
+import json
+
+from flask import Blueprint, Response, abort, request
 from flask_login import login_required
 from flask_parameter_validation import Json, Query, Route, ValidateParameters
 from geonature.core.gn_permissions.decorators import check_cruved_scope
@@ -18,6 +20,7 @@ from calculatrice_monitoring.schemas import (
     IndicatorDetailsSchema,
     IndicatorSchema,
     ProtocolSchema,
+    ReferenceTableCreationSchema,
     ReferenceTableSchema,
     VizBlockConfigSchema,
 )
@@ -296,3 +299,26 @@ eros a suscipit.</p>
 def get_reference_tables():
     reftables = db.session.execute(db.select(ReferenceTable)).scalars()
     return ReferenceTableSchema().jsonify(reftables, many=True)
+
+
+@blueprint.route("/reftables/<int:reftable_id>/data", methods=["GET"])
+@check_cruved_scope(action="R", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def get_reference_table_data(reftable_id: int):
+    error_msg = f"Reference table {reftable_id} not found"
+    reftable = db.get_or_404(ReferenceTable, reftable_id, description=error_msg)
+    return Response(reftable.data, 200, mimetype="text/plain")
+
+
+@blueprint.route("/reftables", methods=["POST"])
+@check_cruved_scope(action="C", module_code=MODULE_CODE, object_code="CALC_ADMIN_INDICATOR")
+def create_reference_table():
+    # TODO:
+    # - vérifier encodage fichier
+    # - vérifier fichier CSV
+    fields = json.loads(request.form["fields"])
+    data = ReferenceTableCreationSchema().load(fields)
+    reftable = ReferenceTable(**data)
+    reftable.data = request.files["file"].read().decode("utf-8")
+    db.session.add(reftable)
+    db.session.commit()
+    return ReferenceTableSchema().jsonify(reftable), 201

--- a/backend/calculatrice_monitoring/schemas.py
+++ b/backend/calculatrice_monitoring/schemas.py
@@ -40,6 +40,12 @@ class ReferenceTableSchema(ma.SQLAlchemyAutoSchema):
         exclude = ["data"]
 
 
+class ReferenceTableCreationSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = ReferenceTable
+        dump_only = ["description", "id_reference_table", "data"]
+
+
 class IndicatorSchema(ma.SQLAlchemyAutoSchema):
     id_indicator = ma.Integer(data_key="id")
     id_protocol = ma.Integer(data_key="protocolId")

--- a/backend/calculatrice_monitoring/tests/test_routes.py
+++ b/backend/calculatrice_monitoring/tests/test_routes.py
@@ -1,8 +1,13 @@
+import json
+from pathlib import Path
+from typing import Optional
+
 import pytest
 from flask import url_for
 from flask_login import logout_user
 from geonature.utils.env import db
 from pypnusershub.tests.utils import set_logged_user
+from werkzeug.datastructures import Headers
 
 from calculatrice_monitoring.models import Indicator, VizBlockConfig, VizBlockType
 
@@ -813,3 +818,69 @@ class TestGetRerenceTables:
         set_logged_user(client, users["public"])
         response = client.get(url_for("calculatrice.get_reference_tables"))
         assert response.status_code == 403
+
+
+class TestCreateReferenceTable:
+    @staticmethod
+    def _get_payload(name: Optional[str] = "My ref table"):
+        filename = Path(__file__).parent.parent / "./migrations/data/indices_he.csv"
+        datafile = open(filename, "rb")
+        fields = {"code": "my_table"}
+        if name:
+            fields["name"] = name
+        return {
+            "file": (datafile, "indices_he.csv"),
+            "fields": json.dumps(fields),
+        }
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_reftable(self, client, users):
+        set_logged_user(client, users["admin"])
+        payload = self._get_payload()
+        response = client.post(
+            url_for("calculatrice.create_reference_table"),
+            data=payload,
+            headers=Headers({"Content-Type": "multipart/form-data"}),
+        )
+
+        assert response.status_code == 201
+        reftable = response.json
+        assert "name" in reftable
+        assert reftable["name"] == "My ref table"
+        assert "code" in reftable
+        assert reftable["code"] == "my_table"
+
+    @pytest.mark.usefixtures("calculatrice_permissions", "users")
+    def test_create_reftable_login_required_error(self, client):
+        logout_user()
+        payload = self._get_payload()
+        response = client.post(
+            url_for("calculatrice.create_reference_table"),
+            data=payload,
+            headers=Headers({"Content-Type": "multipart/form-data"}),
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_reftable_needs_create_permission_error(self, client, users):
+        # `gestionnaire` only has the R permission on CALC_ADMIN_INDICATOR, not C.
+        set_logged_user(client, users["gestionnaire"])
+        payload = self._get_payload()
+        response = client.post(
+            url_for("calculatrice.create_reference_table"),
+            data=payload,
+            headers=Headers({"Content-Type": "multipart/form-data"}),
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("calculatrice_permissions")
+    def test_create_indicator_missing_name_error(self, client, users):
+        set_logged_user(client, users["admin"])
+        payload = self._get_payload(name=None)
+        response = client.post(
+            url_for("calculatrice.create_reference_table"),
+            data=payload,
+            headers=Headers({"Content-Type": "multipart/form-data"}),
+        )
+        assert response.status_code == 400
+        assert "name" in response.json

--- a/frontend/app/components/module/module.component.css
+++ b/frontend/app/components/module/module.component.css
@@ -6,11 +6,13 @@ h1 {
   padding: 0;
 }
 
-.indicators {
-  background-color: white;
+.admin-actions {
+  display: flex;
+  justify-content: end;
 }
 
 .indic-container {
+  background-color: white;
   display: flex;
   min-height: 90vh;
 }

--- a/frontend/app/components/module/module.component.html
+++ b/frontend/app/components/module/module.component.html
@@ -1,4 +1,15 @@
-<div class="indicators container">
+<div class="container">
+  <div class="admin-actions">
+    <button
+      *ngIf="canReadReferenceTables()"
+      [routerLink]="['/calculatrice/reference-tables']"
+      class="mb-2 mt-2"
+      mat-raised-button
+      color="primary"
+    >
+      Gérer tableaux de référence
+    </button>
+  </div>
   <div class="indic-container">
     <div class="indic-protocol-list">
       <h3>Protocoles</h3>

--- a/frontend/app/components/module/module.component.ts
+++ b/frontend/app/components/module/module.component.ts
@@ -65,4 +65,8 @@ export class ModuleComponent implements OnInit {
   canReadIndicator(): boolean {
     return this.getAdminPerm('R') > 0;
   }
+
+  canReadReferenceTables(): boolean {
+    return this.getAdminPerm('R') > 0;
+  }
 }

--- a/frontend/app/components/reftable-form/reftable-form.component.css
+++ b/frontend/app/components/reftable-form/reftable-form.component.css
@@ -1,0 +1,5 @@
+.form-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/frontend/app/components/reftable-form/reftable-form.component.html
+++ b/frontend/app/components/reftable-form/reftable-form.component.html
@@ -1,0 +1,62 @@
+<div class="container">
+  <a
+    mat-raised-button
+    routerLink="/calculatrice/reference-tables"
+    class="mb-2"
+  >
+    <mat-icon>chevron_left</mat-icon>
+    Retour
+  </a>
+  <div class="card">
+    <div class="card-header">
+      <h2>Créer un tableau de référence</h2>
+    </div>
+    <div class="card-body">
+      <form
+        [formGroup]="form"
+        (ngSubmit)="onSubmit()"
+      >
+        <div class="form-inputs">
+          <div>
+            <label for="name">Nom</label>
+            <input
+              id="name"
+              type="text"
+              formControlName="name"
+              class="form-control"
+            />
+          </div>
+          <div>
+            <label for="code">Code</label>
+            <input
+              id="code"
+              type="text"
+              formControlName="code"
+              class="form-control"
+            />
+          </div>
+          <div>
+            <label for="file-input">Importer fichier CSV</label>
+            <input
+              id="file-input"
+              type="file"
+              formControlName="file"
+              (change)="onFileChange($event)"
+              class="form-control"
+            />
+          </div>
+        </div>
+        <hr />
+        <button
+          type="submit"
+          mat-raised-button
+          color="primary"
+          id="validate"
+          [disabled]="!form.valid"
+        >
+          Valider
+        </button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/reftable-form/reftable-form.component.ts
+++ b/frontend/app/components/reftable-form/reftable-form.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Validators } from '@librairies/@angular/forms';
+import { catchError } from 'rxjs/operators';
+import { ReferenceTable } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+import { UtilsService } from '../../services/utils.service';
+
+@Component({
+  selector: 'pnx-calc-reftable-form',
+  templateUrl: './reftable-form.component.html',
+  styleUrls: ['./reftable-form.component.css'],
+})
+export class ReferenceTableFormComponent {
+  form: FormGroup;
+  file: File;
+
+  constructor(
+    private _data: DataService,
+    private _formBuilder: FormBuilder,
+    private _router: Router,
+    private _utils: UtilsService
+  ) {
+    this.form = this._formBuilder.group({
+      file: [null, Validators.required],
+      name: ['', Validators.required],
+      code: ['', Validators.required],
+    });
+  }
+
+  onFileChange(event) {
+    let fileList: FileList = event.target.files;
+    if (fileList.length < 1) {
+      return;
+    }
+    this.file = fileList[0];
+  }
+
+  onSubmit() {
+    if (this.form.valid) {
+      this._data
+        .createReferenceTable(
+          {
+            name: this.form.controls.name.value,
+            code: this.form.controls.code.value,
+          },
+          this.file
+        )
+        .pipe(catchError(this._utils.handleError))
+        .subscribe((data: ReferenceTable) => {
+          this._router.navigate(['/calculatrice/reference-tables']);
+        });
+    }
+  }
+}

--- a/frontend/app/components/reftables/reftables.component.html
+++ b/frontend/app/components/reftables/reftables.component.html
@@ -1,0 +1,96 @@
+<div class="container">
+  <a
+    mat-raised-button
+    routerLink="/calculatrice"
+    class="mb-2"
+  >
+    <mat-icon>chevron_left</mat-icon>
+    Retour
+  </a>
+  <div class="card">
+    <div class="card-header">
+      <h3>Tableaux de référence</h3>
+    </div>
+    <div class="card-body">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Nom</th>
+            <th>Code</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let refTable of referenceTables">
+            <td>{{ refTable.name }}</td>
+            <td class="ref-table-code">{{ refTable.code }}</td>
+            <td>
+              <ng-container *ngIf="canEditReferenceTable(); else noEditButton">
+                <button
+                  mat-icon-button
+                  matTooltip="Éditer le tableau"
+                >
+                  <mat-icon>edit</mat-icon>
+                </button>
+              </ng-container>
+              <ng-template #noEditButton>
+                <button
+                  mat-icon-button
+                  [disabled]="true"
+                >
+                  <mat-icon matTooltip="Vous n'avez pas l'autorisation d'éditer">edit</mat-icon>
+                </button>
+              </ng-template>
+              <ng-container *ngIf="canExportReferenceTable(); else noExportButton">
+                <button
+                  mat-icon-button
+                  matTooltip="Exporter le tableau"
+                  (click)="downloadFile(refTable)"
+                >
+                  <mat-icon>download</mat-icon>
+                </button>
+              </ng-container>
+              <ng-template #noExportButton>
+                <button
+                  mat-icon-button
+                  [disabled]="true"
+                >
+                  <mat-icon matTooltip="Vous n'avez pas l'autorisation d'exporter">
+                    download
+                  </mat-icon>
+                </button>
+              </ng-template>
+              <ng-container *ngIf="canDeleteReferenceTable(); else noDeleteButton">
+                <button
+                  mat-icon-button
+                  matTooltip="Supprimer le tableau"
+                >
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </ng-container>
+              <ng-template #noDeleteButton>
+                <button
+                  mat-icon-button
+                  [disabled]="true"
+                >
+                  <mat-icon matTooltip="Vous n'avez pas l'autorisation de supprimer">
+                    delete
+                  </mat-icon>
+                </button>
+              </ng-template>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <button
+        *ngIf="canCreateReferenceTable()"
+        [routerLink]="['/calculatrice/reference-table/create']"
+        class="mt-2 mb-2"
+        mat-raised-button
+        color="primary"
+      >
+        Ajouter un tableau de référence
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/reftables/reftables.component.ts
+++ b/frontend/app/components/reftables/reftables.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { ModuleService } from '@geonature/services/module.service';
+import { saveAs } from 'file-saver';
+import { ReferenceTable } from '../../interfaces';
+import { DataService } from '../../services/data.service';
+
+@Component({
+  selector: 'pnx-calc-reftables',
+  templateUrl: './reftables.component.html',
+  styleUrls: ['./reftables.component.css'],
+})
+export class ReferenceTablesComponent implements OnInit {
+  protected referenceTables: Array<ReferenceTable> = [];
+
+  constructor(
+    private _data: DataService,
+    private _moduleService: ModuleService
+  ) {}
+
+  ngOnInit() {
+    this._data.getReferenceTables().subscribe((data: Array<ReferenceTable>) => {
+      this.referenceTables = data;
+    });
+  }
+
+  downloadFile(referenceTable: ReferenceTable) {
+    this._data.getReferenceTableData(referenceTable).subscribe((result) => {
+      saveAs(result, 'reftable.csv');
+    });
+  }
+
+  private getAdminPerm(perm: string): number {
+    return this._moduleService.currentModule.module_objects.CALC_ADMIN_INDICATOR?.cruved[perm] || 0;
+  }
+
+  canCreateReferenceTable(): boolean {
+    return this.getAdminPerm('C') > 0;
+  }
+
+  canEditReferenceTable(): boolean {
+    return this.getAdminPerm('U') > 0;
+  }
+
+  canExportReferenceTable(): boolean {
+    return this.getAdminPerm('E') > 0;
+  }
+
+  canDeleteReferenceTable(): boolean {
+    return this.getAdminPerm('D') > 0;
+  }
+}

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -17,6 +17,8 @@ import { IndicatorVizBlocksFormComponent } from './components/indicator-viz-bloc
 import { ScalarVizBlockFormComponent } from './components/indicator-viz-blocks-form/scalar-viz-block-form/scalar-viz-block-form.component';
 import { VizBlockFormComponent } from './components/indicator-viz-blocks-form/viz-block-form/viz-block-form.component';
 import { ModuleComponent } from './components/module/module.component';
+import { ReferenceTableFormComponent } from './components/reftable-form/reftable-form.component';
+import { ReferenceTablesComponent } from './components/reftables/reftables.component';
 import { VisualizationBlockComponent } from './components/visualization-block/visualization-block.component';
 import { VisualizationChartComponent } from './components/visualization-chart/visualization-chart.component';
 import { VisualizationPageComponent } from './components/visualization-page/visualization-page.component';
@@ -32,6 +34,8 @@ const routes: Routes = [
   { path: 'indicator/:indicatorId/edit', component: IndicatorFormComponent },
   { path: 'indicator/:indicatorId/edit-code', component: IndicatorCodeEditorComponent },
   { path: 'indicator/:indicatorId/viz-blocks', component: IndicatorVizBlocksFormComponent },
+  { path: 'reference-tables', component: ReferenceTablesComponent },
+  { path: 'reference-table/create', component: ReferenceTableFormComponent },
   { path: 'visualization/:indicatorId/params', component: VisualizationParamsFormComponent },
   { path: 'visualization/:indicatorId', component: VisualizationPageComponent },
 ];
@@ -46,6 +50,8 @@ const routes: Routes = [
     VizBlockFormComponent,
     ScalarVizBlockFormComponent,
     BarChartVizBlockFormComponent,
+    ReferenceTablesComponent,
+    ReferenceTableFormComponent,
     VisualizationParamsFormComponent,
     VisualizationPageComponent,
     VisualizationBlockComponent,

--- a/frontend/app/interfaces.ts
+++ b/frontend/app/interfaces.ts
@@ -31,6 +31,13 @@ export interface Protocol {
 export interface ReferenceTable {
   id: number;
   name: string;
+  // TODO: ajouter description
+  // description?: string;
+  code: string;
+}
+
+export interface ReferenceTableAttributes {
+  name: string;
   code: string;
 }
 

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -10,6 +10,7 @@ import {
   IndicatorDetails,
   Protocol,
   ReferenceTable,
+  ReferenceTableAttributes,
   Site,
   SitesGroup,
   VisualizationBlockConfigPayload,
@@ -192,6 +193,23 @@ export class DataService {
   getReferenceTables() {
     return this._http.get<Array<ReferenceTable>>(
       `${this._config.API_ENDPOINT}/calculatrice/reftables`
+    );
+  }
+
+  getReferenceTableData(referenceTable: ReferenceTable) {
+    return this._http.get(
+      `${this._config.API_ENDPOINT}/calculatrice/reftables/${referenceTable.id}/data`,
+      { responseType: 'blob' }
+    );
+  }
+
+  createReferenceTable(fields: ReferenceTableAttributes, file: File) {
+    let formData = new FormData();
+    formData.append('file', file);
+    formData.append('fields', JSON.stringify(fields));
+    return this._http.post<ReferenceTable>(
+      `${this._config.API_ENDPOINT}/calculatrice/reftables`,
+      formData
     );
   }
 


### PR DESCRIPTION
Issue: #24 

**Description**

Deux nouvelles pages :

- liste des tableaux de référence avec les actions possibles pour chacun + bouton "Ajouter"
  + action Exporter implémentée
  + actions Éditer/Supprimer non-implémentées 
- un formulaire pour importer un nouveau tableau de référence à partir d'un fichier CSV

**Points non-implémentés**

- édition d'un reftable (juste pour modifier le nom mais pas le code, potentiellement utilisé)
- suppression d'un reftable (il faudra empêcher si utilisé)
- le modèle du reftable a une description qui n'est pas géré sur les pages admin pour l'instant
- validation du code d'un nouveau reftable
  + doit être unique
  + doit respecter les règles syntaxiques des variables Python
  + (éventuellement mettre un namespace pour les reftables dans le contexte d'exécution des codes : permettrait d'éviter les conflits de nommage avec les variables !)
- muscler la validation du fichier CSV importé
  + taille maximum
  + formatage CSV